### PR TITLE
Remove dependency commons-codec

### DIFF
--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -67,32 +67,6 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <!-- Remove extraneous files from the jarjar'ed Apache Commons Codec
-               Library. -->
-          <execution>
-            <id>scrub</id>
-            <phase>package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <jar destfile="target/scrubbed.jar" filesetmanifest="merge">
-                  <zipfileset src="target/google-http-client-${project.version}.jar">
-                    <exclude name="**/org/apache/commons/codec/language/bm/*.txt"/>
-                    <exclude name="META-INF/*.txt"/>
-                    <exclude name="META-INF/maven/**"/>
-                  </zipfileset>
-                </jar>
-                <move file="target/scrubbed.jar" tofile="target/google-http-client-${project.version}.jar"/>
-              </target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>  

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -22,7 +22,6 @@
           <links>
             <link>http://download.oracle.com/javase/1.5.0/docs/api/</link>
             <link>http://docs.guava-libraries.googlecode.com/git-history/v13.0.1/javadoc</link>
-            <link>http://commons.apache.org/proper/commons-codec/javadocs/api-release</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>
@@ -40,9 +39,7 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Use jarjar to include a private copy of Apache Commons Codec library
-           to avoid a runtime dependency conflict with Android which includes
-           an older version of that library, as well as Guava JDK5. -->
+      <!-- Use jarjar to include a private copy of Guava JDK5. -->
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>jarjar-maven-plugin</artifactId>
@@ -54,14 +51,9 @@
             </goals>
             <configuration>
               <includes>
-                <include>commons-codec:commons-codec</include>
                 <include>com.google.guava:guava-jdk5</include>
               </includes>
               <rules>
-                <rule>
-                  <pattern>org.apache.commons.codec.**</pattern>
-                  <result>com.google.api.client.repackaged.org.apache.commons.codec.@1</result>
-                </rule>
                 <rule>
                   <pattern>com.google.common.**</pattern>
                   <result>com.google.api.client.repackaged.com.google.common.@1</result>
@@ -158,11 +150,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>

--- a/google-http-client/src/main/java/com/google/api/client/util/Base64.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Base64.java
@@ -17,8 +17,7 @@ package com.google.api.client.util;
 import com.google.common.io.BaseEncoding;
 
 /**
- * Proxy for base 64 encoding/decoding which matches the Base64 interface in Apache Commons (for
- * historical reasons).
+ * Proxy for Guava's {@link BaseEncoding#base64()} and {@link BaseEncoding#base64Url()}.
  *
  * @author Yaniv Inbar
  * @since 1.8
@@ -31,12 +30,13 @@ public class Base64 {
    * @param binaryData binary data to encode or {@code null} for {@code null} result
    * @return byte[] containing Base64 characters in their UTF-8 representation or {@code null} for
    * {@code null} input
+   * @see Base64#encodeBase64String(byte[])
    */
   public static byte[] encodeBase64(byte[] binaryData) {
     if (binaryData == null) {
       return null;
     }
-    return BaseEncoding.base64().encode(binaryData).getBytes();
+    return StringUtils.getBytesUtf8(encodeBase64String(binaryData));
   }
 
   /**
@@ -44,6 +44,7 @@ public class Base64 {
    *
    * @param binaryData binary data to encode or {@code null} for {@code null} result
    * @return String containing Base64 characters or {@code null} for {@code null} input
+   * @see BaseEncoding#encode(byte[])
    */
   public static String encodeBase64String(byte[] binaryData) {
     if (binaryData == null) {
@@ -59,12 +60,13 @@ public class Base64 {
    * @param binaryData binary data to encode or {@code null} for {@code null} result
    * @return byte[] containing Base64 characters in their UTF-8 representation or {@code null} for
    * {@code null} input
+   * @see Base64#encodeBase64URLSafeString(byte[])
    */
   public static byte[] encodeBase64URLSafe(byte[] binaryData) {
     if (binaryData == null) {
       return null;
     }
-    return BaseEncoding.base64Url().omitPadding().encode(binaryData).getBytes();
+    return StringUtils.getBytesUtf8(encodeBase64URLSafeString(binaryData));
   }
 
   /**
@@ -73,6 +75,7 @@ public class Base64 {
    *
    * @param binaryData binary data to encode or {@code null} for {@code null} result
    * @return String containing Base64 characters or {@code null} for {@code null} input
+   * @see BaseEncoding#encode(byte[])
    */
   public static String encodeBase64URLSafeString(byte[] binaryData) {
     if (binaryData == null) {
@@ -86,12 +89,13 @@ public class Base64 {
    *
    * @param base64Data Byte array containing Base64 data or {@code null} for {@code null} result
    * @return Array containing decoded data or {@code null} for {@code null} input
+   * @see Base64#decodeBase64(java.lang.String)
    */
   public static byte[] decodeBase64(byte[] base64Data) {
     if (base64Data == null) {
       return null;
     }
-    return decodeBase64(new String(base64Data));
+    return decodeBase64(StringUtils.newStringUtf8(base64Data));
   }
 
   /**
@@ -104,7 +108,6 @@ public class Base64 {
     if (base64String == null) {
       return null;
     }
-
     try {
       return BaseEncoding.base64().decode(base64String);
     } catch (IllegalArgumentException e) {

--- a/google-http-client/src/main/java/com/google/api/client/util/StringUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/StringUtils.java
@@ -20,14 +20,6 @@ import java.io.UnsupportedEncodingException;
 /**
  * Utilities for strings.
  *
- * <p>
- * Some of these methods are a proxy for version 1.6 (or newer) of the Apache Commons Codec
- * {@link StringUtils} implementation. This is needed in order to support platforms like Android
- * which already include an older version of the Apache Commons Codec (Android includes version
- * 1.3). To avoid a dependency library conflict, this library includes a reduced private copy of
- * version 1.6 (or newer) of the Apache Commons Codec (using a tool like jarjar).
- * </p>
- *
  * @since 1.8
  * @author Yaniv Inbar
  */
@@ -50,11 +42,15 @@ public class StringUtils {
    *         according the the Java specification.
    * @see <a href="http://download.oracle.com/javase/1.5.0/docs/api/java/nio/charset/Charset.html"
    *      >Standard charsets</a>
-   * @see org.apache.commons.codec.binary.StringUtils#getBytesUtf8(String)
+   * @see String#getBytes(String)
    * @since 1.8
    */
   public static byte[] getBytesUtf8(String string) {
-    return org.apache.commons.codec.binary.StringUtils.getBytesUtf8(string);
+    try {
+      return string.getBytes("UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException();
+    }
   }
 
   /**
@@ -66,11 +62,15 @@ public class StringUtils {
    *         charset, or <code>null</code> if the input byte array was <code>null</code>.
    * @throws IllegalStateException Thrown when a {@link UnsupportedEncodingException} is caught,
    *         which should never happen since the charset is required.
-   * @see org.apache.commons.codec.binary.StringUtils#newStringUtf8(byte[])
+   * @see String#String(byte[], String)
    * @since 1.8
    */
   public static String newStringUtf8(byte[] bytes) {
-    return org.apache.commons.codec.binary.StringUtils.newStringUtf8(bytes);
+    try {
+      return new String(bytes, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException();
+    }
   }
 
   private StringUtils() {


### PR DESCRIPTION
Replace usages by native JDK methods (available since 1.1),
or Guava methods (available since 14.0).
