### PR TITLE
Release google-http-java-client v1.26.0

### DIFF
--- a/google-http-client-android-test/pom.xml
+++ b/google-http-client-android-test/pom.xml
@@ -4,7 +4,7 @@
   <groupId>google-http-client</groupId>
   <artifactId>google-http-client-android-test</artifactId>
   <name>Test project for google-http-client-android.</name>
-  <version>1.26.0-SNAPSHOT</version>
+  <version>1.26.0</version>
   <packaging>apk</packaging>
 
   <build>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-android</artifactId>
-      <version>1.26.0-SNAPSHOT</version>
+      <version>1.26.0</version>
       <exclusions>
         <exclusion>
           <artifactId>android</artifactId>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-test</artifactId>
-      <version>1.26.0-SNAPSHOT</version>
+      <version>1.26.0</version>
       <exclusions>
         <exclusion>
           <artifactId>junit</artifactId>

--- a/google-http-client-android/pom.xml
+++ b/google-http-client-android/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-android</artifactId>

--- a/google-http-client-appengine/pom.xml
+++ b/google-http-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-appengine</artifactId>

--- a/google-http-client-assembly/pom.xml
+++ b/google-http-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.http-client</groupId>

--- a/google-http-client-findbugs/pom.xml
+++ b/google-http-client-findbugs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-findbugs</artifactId>

--- a/google-http-client-gson/pom.xml
+++ b/google-http-client-gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-gson</artifactId>

--- a/google-http-client-jackson/pom.xml
+++ b/google-http-client-jackson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jackson</artifactId>

--- a/google-http-client-jackson2/pom.xml
+++ b/google-http-client-jackson2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jackson2</artifactId>

--- a/google-http-client-jdo/pom.xml
+++ b/google-http-client-jdo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jdo</artifactId>

--- a/google-http-client-protobuf/pom.xml
+++ b/google-http-client-protobuf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-protobuf</artifactId>

--- a/google-http-client-test/pom.xml
+++ b/google-http-client-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-test</artifactId>

--- a/google-http-client-xml/pom.xml
+++ b/google-http-client-xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-xml</artifactId>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-parent</artifactId>
-  <version>1.26.0-SNAPSHOT</version>
+  <version>1.26.0</version>
   <packaging>pom</packaging>
   <name>Parent for the Google HTTP Client Library for Java</name>
 

--- a/samples/dailymotion-simple-cmdline-sample/pom.xml
+++ b/samples/dailymotion-simple-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>dailymotion-simple-cmdline-sample</artifactId>

--- a/samples/googleplus-simple-cmdline-sample/pom.xml
+++ b/samples/googleplus-simple-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>googleplus-simple-cmdline-sample</artifactId>


### PR DESCRIPTION
This pull request was generated using releasetool.

### Implementation Changes
- Fix throwIfFalseEOF if skip method was called before read ([#447](https://github.com/googleapis/google-http-java-client/pull/447))
- Fix compilation for Java 10 ([#454](https://github.com/googleapis/google-http-java-client/pull/454))
- fix arraymap iterator remove issue ([#371](https://github.com/googleapis/google-http-java-client/pull/371))

### New Features
- Include Automatic-Module-Name in MANIFEST.MF ([#400](https://github.com/googleapis/google-http-java-client/pull/400))

### Dependencies
- Sync dependencies with api client ([#450](https://github.com/googleapis/google-http-java-client/pull/450))

### Documentation

### Internal / Testing Changes
- Add Kokoro CI config ([#451](https://github.com/googleapis/google-http-java-client/pull/451))
- Generated commit - bump version to 1.26.0-SNAPSHOT ([#449](https://github.com/googleapis/google-http-java-client/pull/449))