### PR TITLE
Fix code.google.com links. Fix maven version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 bin/
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ are welcome.
 
 Java Version | Status
 ------------ | ------
-Java 7 | [![Kokoro CI](http://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java7.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java7.html)
-Java 8 | [![Kokoro CI](http://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java8.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java8.html)
-Java 10 | [![Kokoro CI](http://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java10.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java10.html)
+Java 7 | [![Kokoro CI](https://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java7.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java7.html)
+Java 8 | [![Kokoro CI](https://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java8.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java8.html)
+Java 10 | [![Kokoro CI](https://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java10.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/google-http-java-client/java10.html)
 
 ## Links
 
-- [Discuss](http://groups.google.com/group/google-http-java-client)
+- [Discuss](https://groups.google.com/group/google-http-java-client)

--- a/google-http-client-android/src/main/java/com/google/api/client/extensions/android/json/AndroidJsonFactory.java
+++ b/google-http-client-android/src/main/java/com/google/api/client/extensions/android/json/AndroidJsonFactory.java
@@ -76,7 +76,7 @@ public class AndroidJsonFactory extends JsonFactory {
   @Override
   public JsonParser createJsonParser(InputStream in) {
     // TODO(mlinder): Charset should be detected automatically by the parser. Related to:
-    // http://code.google.com/p/google-http-java-client/issues/detail?id=6
+    // http://github.com/googleapis/google-http-java-client/issues/6
     return createJsonParser(new InputStreamReader(in, Charsets.UTF_8));
   }
 

--- a/google-http-client-android/src/main/java/com/google/api/client/extensions/android/json/AndroidJsonParser.java
+++ b/google-http-client-android/src/main/java/com/google/api/client/extensions/android/json/AndroidJsonParser.java
@@ -151,7 +151,7 @@ class AndroidJsonParser extends JsonParser {
       }
     }
     // work around bug in GSON parser that it throws an EOFException for an empty document
-    // see http://code.google.com/p/google-gson/issues/detail?id=330
+    // see http://github.com/google/gson/issues/330
     android.util.JsonToken peek;
     try {
       peek = reader.peek();

--- a/google-http-client-appengine/pom.xml
+++ b/google-http-client-appengine/pom.xml
@@ -16,7 +16,7 @@
         <configuration>
           <links>
             <link>http://download.oracle.com/javase/6/docs/api/</link>
-            <link>http://code.google.com/appengine/docs/java/javadoc</link>
+            <link>https://cloud.google.com/appengine/docs/standard/java/javadoc/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/google-http-client-appengine/src/main/java/com/google/api/client/extensions/appengine/http/UrlFetchTransport.java
+++ b/google-http-client-appengine/src/main/java/com/google/api/client/extensions/appengine/http/UrlFetchTransport.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 
 /**
  * Thread-safe HTTP transport for Google App Engine based on <a
- * href="http://code.google.com/appengine/docs/java/urlfetch/">URL Fetch</a>.
+ * href="https://cloud.google.com/appengine/docs/standard/java/issue-requests">URL Fetch</a>.
  *
  * <p>
  * Implementation is thread-safe. For maximum efficiency, applications should use a single

--- a/google-http-client-appengine/src/main/java/com/google/api/client/extensions/appengine/http/package-info.java
+++ b/google-http-client-appengine/src/main/java/com/google/api/client/extensions/appengine/http/package-info.java
@@ -14,7 +14,7 @@
 
 /**
  * HTTP Transport library for Google API's based on <a
- * href="http://code.google.com/appengine/docs/java/urlfetch/">URL Fetch in Google App Engine</a>.
+ * href="https://cloud.google.com/appengine/docs/standard/java/issue-requests">URL Fetch in Google App Engine</a>.
  *
  * @since 1.10
  * @author Yaniv Inbar

--- a/google-http-client-assembly/dependencies/google-http-client-android-dependencies.html
+++ b/google-http-client-assembly/dependencies/google-http-client-android-dependencies.html
@@ -62,7 +62,7 @@
 <th>License</th></tr>
 <tr class="b">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">google-http-client</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">google-http-client</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr></table></div><a name="Project_Dependencies_provided"></a>
@@ -194,7 +194,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-android">https://github.com/google/google-http-java-client/google-http-client-android</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-android">https://github.com/googleapis/google-http-java-client/google-http-client-android</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.android:android:jar:4.1.1.4 (provided) <img id="_img3" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep2', '_img3' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep2" style="display:none">
@@ -297,7 +297,7 @@
 <td>
 <p><b>Description: </b>Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,
     including Java 5 (or higher) desktop (SE) and web (EE), Android, and Google App Engine.</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">https://github.com/google/google-http-java-client/google-http-client</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">https://github.com/googleapis/google-http-java-client/google-http-client</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.code.findbugs:jsr305:jar:3.0.2 (compile) <img id="_img23" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep22', '_img23' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep22" style="display:none">

--- a/google-http-client-assembly/dependencies/google-http-client-appengine-dependencies.html
+++ b/google-http-client-assembly/dependencies/google-http-client-appengine-dependencies.html
@@ -62,7 +62,7 @@
 <th>License</th></tr>
 <tr class="b">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">google-http-client</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">google-http-client</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr></table></div><a name="Project_Dependencies_test"></a>
@@ -96,7 +96,7 @@
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
 <tr class="a">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-test">google-http-client-test</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-test">google-http-client-test</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
@@ -200,7 +200,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-appengine">https://github.com/google/google-http-java-client/google-http-client-appengine</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-appengine">https://github.com/googleapis/google-http-java-client/google-http-client-appengine</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.http-client:google-http-client:jar:1.26.0-SNAPSHOT (compile) <img id="_img3" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep2', '_img3' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep2" style="display:none">
@@ -211,7 +211,7 @@
 <td>
 <p><b>Description: </b>Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,
     including Java 5 (or higher) desktop (SE) and web (EE), Android, and Google App Engine.</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">https://github.com/google/google-http-java-client/google-http-client</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">https://github.com/googleapis/google-http-java-client/google-http-client</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.code.findbugs:jsr305:jar:3.0.2 (compile) <img id="_img5" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep4', '_img5' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep4" style="display:none">
@@ -281,7 +281,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-test">https://github.com/google/google-http-java-client/google-http-client-test</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-test">https://github.com/googleapis/google-http-java-client/google-http-client-test</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div></li>
 <li>com.google.appengine:appengine-api-1.0-sdk:jar:1.9.64 (provided) <img id="_img19" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep18', '_img19' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep18" style="display:none">
 <table border="0" class="bodyTable">

--- a/google-http-client-assembly/dependencies/google-http-client-dependencies.html
+++ b/google-http-client-assembly/dependencies/google-http-client-dependencies.html
@@ -245,7 +245,7 @@
 <td>
 <p><b>Description: </b>Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,
     including Java 5 (or higher) desktop (SE) and web (EE), Android, and Google App Engine.</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">https://github.com/google/google-http-java-client/google-http-client</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">https://github.com/googleapis/google-http-java-client/google-http-client</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.android:android:jar:1.5_r4 (provided) <img id="_img3" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep2', '_img3' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep2" style="display:none">

--- a/google-http-client-assembly/dependencies/google-http-client-gson-dependencies.html
+++ b/google-http-client-assembly/dependencies/google-http-client-gson-dependencies.html
@@ -62,13 +62,13 @@
 <th>License</th></tr>
 <tr class="b">
 <td>com.google.code.gson</td>
-<td><a class="externalLink" href="http://code.google.com/p/google-gson/">gson</a></td>
+<td><a class="externalLink" href="https://github.com/google/gson">gson</a></td>
 <td>2.1</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
 <tr class="a">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">google-http-client</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">google-http-client</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr></table></div><a name="Project_Dependencies_test"></a>
@@ -90,7 +90,7 @@
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
 <tr class="a">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-test">google-http-client-test</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-test">google-http-client-test</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
@@ -178,7 +178,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-gson">https://github.com/google/google-http-java-client/google-http-client-gson</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-gson">https://github.com/googleapis/google-http-java-client/google-http-client-gson</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.http-client:google-http-client:jar:1.26.0-SNAPSHOT (compile) <img id="_img3" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep2', '_img3' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep2" style="display:none">
@@ -189,7 +189,7 @@
 <td>
 <p><b>Description: </b>Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,
     including Java 5 (or higher) desktop (SE) and web (EE), Android, and Google App Engine.</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">https://github.com/google/google-http-java-client/google-http-client</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">https://github.com/googleapis/google-http-java-client/google-http-client</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.code.findbugs:jsr305:jar:3.0.2 (compile) <img id="_img5" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep4', '_img5' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep4" style="display:none">
@@ -259,7 +259,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-test">https://github.com/google/google-http-java-client/google-http-client-test</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-test">https://github.com/googleapis/google-http-java-client/google-http-client-test</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div></li>
 <li>junit:junit:jar:4.8.2 (test) <img id="_img19" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep18', '_img19' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep18" style="display:none">
 <table border="0" class="bodyTable">
@@ -277,7 +277,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Google Gson library</p>
-<p><b>URL: </b><a class="externalLink" href="http://code.google.com/p/google-gson/">http://code.google.com/p/google-gson/</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/google/gson">https://github.com/google/gson</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div></li>
 <li>com.google.guava:guava:jar:20.0 (test) <img id="_img23" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep22', '_img23' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep22" style="display:none">
 <table border="0" class="bodyTable">

--- a/google-http-client-assembly/dependencies/google-http-client-jackson-dependencies.html
+++ b/google-http-client-assembly/dependencies/google-http-client-jackson-dependencies.html
@@ -62,7 +62,7 @@
 <th>License</th></tr>
 <tr class="b">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">google-http-client</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">google-http-client</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
@@ -90,7 +90,7 @@
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
 <tr class="a">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-test">google-http-client-test</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-test">google-http-client-test</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
@@ -178,7 +178,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-jackson">https://github.com/google/google-http-java-client/google-http-client-jackson</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-jackson">https://github.com/googleapis/google-http-java-client/google-http-client-jackson</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.http-client:google-http-client:jar:1.26.0-SNAPSHOT (compile) <img id="_img3" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep2', '_img3' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep2" style="display:none">
@@ -189,7 +189,7 @@
 <td>
 <p><b>Description: </b>Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,
     including Java 5 (or higher) desktop (SE) and web (EE), Android, and Google App Engine.</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">https://github.com/google/google-http-java-client/google-http-client</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">https://github.com/googleapis/google-http-java-client/google-http-client</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.code.findbugs:jsr305:jar:3.0.2 (compile) <img id="_img5" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep4', '_img5' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep4" style="display:none">
@@ -259,7 +259,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-test">https://github.com/google/google-http-java-client/google-http-client-test</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-test">https://github.com/googleapis/google-http-java-client/google-http-client-test</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div></li>
 <li>junit:junit:jar:4.8.2 (test) <img id="_img19" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep18', '_img19' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep18" style="display:none">
 <table border="0" class="bodyTable">

--- a/google-http-client-assembly/dependencies/google-http-client-jackson2-dependencies.html
+++ b/google-http-client-assembly/dependencies/google-http-client-jackson2-dependencies.html
@@ -68,7 +68,7 @@
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
 <tr class="a">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">google-http-client</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">google-http-client</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr></table></div><a name="Project_Dependencies_test"></a>
@@ -90,7 +90,7 @@
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
 <tr class="a">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-test">google-http-client-test</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-test">google-http-client-test</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
@@ -178,7 +178,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-jackson2">https://github.com/google/google-http-java-client/google-http-client-jackson2</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-jackson2">https://github.com/googleapis/google-http-java-client/google-http-client-jackson2</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.http-client:google-http-client:jar:1.26.0-SNAPSHOT (compile) <img id="_img3" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep2', '_img3' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep2" style="display:none">
@@ -189,7 +189,7 @@
 <td>
 <p><b>Description: </b>Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,
     including Java 5 (or higher) desktop (SE) and web (EE), Android, and Google App Engine.</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">https://github.com/google/google-http-java-client/google-http-client</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">https://github.com/googleapis/google-http-java-client/google-http-client</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.code.findbugs:jsr305:jar:3.0.2 (compile) <img id="_img5" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep4', '_img5' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep4" style="display:none">
@@ -259,7 +259,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-test">https://github.com/google/google-http-java-client/google-http-client-test</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-test">https://github.com/googleapis/google-http-java-client/google-http-client-test</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div></li>
 <li>junit:junit:jar:4.8.2 (test) <img id="_img19" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep18', '_img19' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep18" style="display:none">
 <table border="0" class="bodyTable">

--- a/google-http-client-assembly/dependencies/google-http-client-jdo-dependencies.html
+++ b/google-http-client-assembly/dependencies/google-http-client-jdo-dependencies.html
@@ -62,7 +62,7 @@
 <th>License</th></tr>
 <tr class="b">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">google-http-client</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">google-http-client</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
@@ -90,7 +90,7 @@
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
 <tr class="a">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-test">google-http-client-test</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-test">google-http-client-test</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
@@ -208,7 +208,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-jdo">https://github.com/google/google-http-java-client/google-http-client-jdo</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-jdo">https://github.com/googleapis/google-http-java-client/google-http-client-jdo</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.http-client:google-http-client:jar:1.26.0-SNAPSHOT (compile) <img id="_img3" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep2', '_img3' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep2" style="display:none">
@@ -219,7 +219,7 @@
 <td>
 <p><b>Description: </b>Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,
     including Java 5 (or higher) desktop (SE) and web (EE), Android, and Google App Engine.</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">https://github.com/google/google-http-java-client/google-http-client</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">https://github.com/googleapis/google-http-java-client/google-http-client</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.code.findbugs:jsr305:jar:3.0.2 (compile) <img id="_img5" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep4', '_img5' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep4" style="display:none">
@@ -289,7 +289,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-test">https://github.com/google/google-http-java-client/google-http-client-test</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-test">https://github.com/googleapis/google-http-java-client/google-http-client-test</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div></li>
 <li>junit:junit:jar:4.8.2 (test) <img id="_img19" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep18', '_img19' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep18" style="display:none">
 <table border="0" class="bodyTable">

--- a/google-http-client-assembly/dependencies/google-http-client-protobuf-dependencies.html
+++ b/google-http-client-assembly/dependencies/google-http-client-protobuf-dependencies.html
@@ -62,7 +62,7 @@
 <th>License</th></tr>
 <tr class="b">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">google-http-client</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">google-http-client</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
@@ -166,7 +166,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-protobuf">https://github.com/google/google-http-java-client/google-http-client-protobuf</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-protobuf">https://github.com/googleapis/google-http-java-client/google-http-client-protobuf</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.http-client:google-http-client:jar:1.26.0-SNAPSHOT (compile) <img id="_img3" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep2', '_img3' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep2" style="display:none">
@@ -177,7 +177,7 @@
 <td>
 <p><b>Description: </b>Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,
     including Java 5 (or higher) desktop (SE) and web (EE), Android, and Google App Engine.</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">https://github.com/google/google-http-java-client/google-http-client</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">https://github.com/googleapis/google-http-java-client/google-http-client</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.code.findbugs:jsr305:jar:3.0.2 (compile) <img id="_img5" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep4', '_img5' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep4" style="display:none">

--- a/google-http-client-assembly/dependencies/google-http-client-xml-dependencies.html
+++ b/google-http-client-assembly/dependencies/google-http-client-xml-dependencies.html
@@ -62,7 +62,7 @@
 <th>License</th></tr>
 <tr class="b">
 <td>com.google.http-client</td>
-<td><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">google-http-client</a></td>
+<td><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">google-http-client</a></td>
 <td>1.26.0-SNAPSHOT</td>
 <td>jar</td>
 <td><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></td></tr>
@@ -172,7 +172,7 @@
 <tr class="b">
 <td>
 <p><b>Description: </b>Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client-xml">https://github.com/google/google-http-java-client/google-http-client-xml</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client-xml">https://github.com/googleapis/google-http-java-client/google-http-client-xml</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.http-client:google-http-client:jar:1.26.0-SNAPSHOT (compile) <img id="_img3" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep2', '_img3' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep2" style="display:none">
@@ -183,7 +183,7 @@
 <td>
 <p><b>Description: </b>Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,
     including Java 5 (or higher) desktop (SE) and web (EE), Android, and Google App Engine.</p>
-<p><b>URL: </b><a class="externalLink" href="https://github.com/google/google-http-java-client/google-http-client">https://github.com/google/google-http-java-client/google-http-client</a></p>
+<p><b>URL: </b><a class="externalLink" href="https://github.com/googleapis/google-http-java-client/google-http-client">https://github.com/googleapis/google-http-java-client/google-http-client</a></p>
 <p><b>Project License: </b><a class="externalLink" href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a></p></td></tr></table></div>
 <ul>
 <li>com.google.code.findbugs:jsr305:jar:3.0.2 (compile) <img id="_img5" src="./images/icon_info_sml.gif" alt="Information" onclick="toggleDependencyDetail( '_dep4', '_img5' );" style="cursor: pointer;vertical-align:text-bottom;"></img><div id="_dep4" style="display:none">

--- a/google-http-client-assembly/readme.html
+++ b/google-http-client-assembly/readme.html
@@ -6,18 +6,15 @@
   <h3>Overview</h3>
   <p>
     High-level details about this library can be found at <a
-      href="http://code.google.com/p/google-http-java-client">http://code.google.com/p/google-http-java-client</a>
+      href="https://github.com/googleapis/google-http-java-client">https://github.com/googleapis/google-http-java-client</a>
   </p>
   <ul>
     <li><a
-      href='http://code.google.com/p/google-http-java-client/wiki/ReleaseNotes#Version_${project.version}'>Release
+      href='https://github.com/googleapis/google-http-java-client/releases/tag/${project.version}'>Release
         Notes</a></li>
     <li><a
-      href='http://javadoc.google-http-java-client.googlecode.com/hg/${project.version}/index.html'>JavaDoc</a></li>
-    <li><a
-      href='http://code.google.com/p/google-http-java-client/wiki/DeveloperGuide'>Developer's
-        Guide</a></li>
-    <li><a href='http://groups.google.com/group/google-http-java-client'>Support</a></li>
+      href='https://googleapis.github.io/google-http-java-client/releases/${project.version}/javadoc/index.html'>JavaDoc</a></li>
+    <li><a href='https://groups.google.com/group/google-http-java-client'>Support</a></li>
   </ul>
 
   <h3>Dependencies and Licenses</h3>
@@ -52,7 +49,7 @@
 
   <h3>Maven Usage</h3>
   For information on how to add these libraries to your Maven project please see
-  <a href='http://code.google.com/p/google-http-java-client/wiki/Setup#Maven'>http://code.google.com/p/google-http-java-client/wiki/Setup#Maven</a>.
+  <a href='https://developers.google.com/api-client-library/java/google-http-java-client/setup#maven'>https://developers.google.com/api-client-library/java/google-http-java-client/setup#maven</a>.
 
   <h3>Eclipse</h3>
   A .classpath file snippet that can be included in your project's .classpath
@@ -74,7 +71,7 @@
   </p>
   <p>
     Please read <a
-      href="http://code.google.com/p/google-http-java-client/wiki/Setup#ProGuard">Setup
+      href="https://developers.google.com/api-client-library/java/google-http-java-client/setup#proguard">Setup
       ProGuard</a> for more details.
   </p>
 
@@ -130,7 +127,7 @@
   <a href='libs'>libs</a> folder also contains properties files that specify the
   location of source jars for Android projects in Eclipse.
   <br /> Please see the
-  <a href='http://code.google.com/p/google-http-java-client/wiki/Android'>Android
+  <a href='https://developers.google.com/api-client-library/java/google-http-java-client/android'>Android
     wiki</a> for the Android Developer's Guide.
 
   <h3>Google App Engine Dependencies</h3>
@@ -142,7 +139,7 @@
   </ul>
   Please see the
   <a
-    href='http://code.google.com/p/google-http-java-client/wiki/GoogleAppEngine'>GoogleAppEngine
+    href='https://developers.google.com/api-client-library/java/google-http-java-client/app-engine'>GoogleAppEngine
     wiki</a> for the Google App Engine Developer's Guide.
 
   <h3>General Purpose Java 5 Environment Dependencies</h3>

--- a/google-http-client-findbugs/src/main/resources/findbugs.xml
+++ b/google-http-client-findbugs/src/main/resources/findbugs.xml
@@ -1,6 +1,6 @@
 <FindbugsPlugin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="findbugsplugin.xsd" pluginid="com.google.api.client.findbugs"
-  provider="Google APIs Client Library" website="https://code.google.com/p/google-http-java-client/">
+  provider="Google APIs Client Library" website="https://github.com/googleapis/google-http-java-client">
 
   <Detector class="com.google.api.client.findbugs.BetaDetector"
     speed="fast"

--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
@@ -64,7 +64,7 @@ public class GsonFactory extends JsonFactory {
   @Override
   public JsonParser createJsonParser(InputStream in) {
     // TODO(mlinder): Parser should try to detect the charset automatically when using GSON
-    // http://code.google.com/p/google-http-java-client/issues/detail?id=6
+    // https://github.com/googleapis/google-http-java-client/issues/6
     return createJsonParser(new InputStreamReader(in, Charsets.UTF_8));
   }
 

--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonParser.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonParser.java
@@ -146,7 +146,7 @@ class GsonParser extends JsonParser {
       }
     }
     // work around bug in GSON parser that it throws an EOFException for an empty document
-    // see http://code.google.com/p/google-gson/issues/detail?id=330
+    // see https://github.com/google/gson/issues/330
     com.google.gson.stream.JsonToken peek;
     try {
       peek = reader.peek();

--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/package-info.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/package-info.java
@@ -14,7 +14,7 @@
 
 /**
  * Low-level implementation of the GSON parser library based on the <a
- * href="http://code.google.com/p/google-gson/">GSON</a> JSON library.
+ * href="https://github.com/google/gson">GSON</a> JSON library.
  *
  * @since 1.3
  * @author Yaniv Inbar

--- a/google-http-client-protobuf/src/main/java/com/google/api/client/http/protobuf/package-info.java
+++ b/google-http-client-protobuf/src/main/java/com/google/api/client/http/protobuf/package-info.java
@@ -14,7 +14,7 @@
 
 /**
  * {@link com.google.api.client.util.Beta} <br/>
- * HTTP utilities for the <a href="http://code.google.com/p/protobuf/">Protocol Buffer</a> format
+ * HTTP utilities for the <a href="https://github.com/protocolbuffers/protobuf">Protocol Buffer</a> format
  * based on the pluggable HTTP library.
  *
  * @since 1.5

--- a/google-http-client-protobuf/src/main/java/com/google/api/client/protobuf/package-info.java
+++ b/google-http-client-protobuf/src/main/java/com/google/api/client/protobuf/package-info.java
@@ -14,7 +14,7 @@
 
 /**
  * {@link com.google.api.client.util.Beta} <br/>
- * Utilities for the <a href="http://code.google.com/p/protobuf/">Protocol Buffer</a> format.
+ * Utilities for the <a href="https://github.com/protocolbuffers/protobuf">Protocol Buffer</a> format.
  *
  * @since 1.5
  * @author Yaniv Inbar

--- a/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
@@ -44,8 +44,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Abstract low-level JSON parser. See
- * <a href="https://code.google.com/p/google-http-java-client/wiki/JSON">
- * https://code.google.com/p/google-http-java-client/wiki/JSON</a>
+ * <a href="https://developers.google.com/api-client-library/java/google-http-java-client/json">
+ * https://developers.google.com/api-client-library/java/google-http-java-client/json</a>
  *
  * <p>
  * Implementation has no fields and therefore thread-safe, but sub-classes are not necessarily

--- a/google-http-client/src/test/java/com/google/api/client/http/UrlEncodedContentTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/UrlEncodedContentTest.java
@@ -39,7 +39,7 @@ public class UrlEncodedContentTest extends TestCase {
         "multi=a&multi=b&multi=c", ArrayMap.of("multi", Arrays.asList("a", "b", "c")));
     subtestWriteTo(
         "multi=a&multi=b&multi=c", ArrayMap.of("multi", new String[] {"a", "b", "c"}));
-    // https://code.google.com/p/google-http-java-client/issues/detail?id=202
+    // https://github.com/googleapis/google-http-java-client/issues/202
     final Map<String, String> params = new LinkedHashMap<String, String>();
     params.put("username", "un");
     params.put("password", "password123;{}");

--- a/instructions.html
+++ b/instructions.html
@@ -7,7 +7,7 @@
 
 <ul>
   <li><a
-    href="https://github.com/google/google-http-java-client">Browse
+    href="https://github.com/googleapis/google-http-java-client">Browse
   Source</a></li>
 </ul>
 
@@ -20,7 +20,7 @@
   href="http://maven.apache.org/download.html">Maven</a>. You may need to set
 your <code>JAVA_HOME</code>.</p>
 
-<pre><code>git clone https://github.com/google/google-http-java-client.git
+<pre><code>git clone https://github.com/googleapis/google-http-java-client.git
 cd google-http-java-client
 mvn install</code></pre>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,23 +13,23 @@
   <packaging>pom</packaging>
   <name>Parent for the Google HTTP Client Library for Java</name>
 
-  <url>https://github.com/google/google-http-java-client</url>
+  <url>https://github.com/googleapis/google-http-java-client</url>
 
   <issueManagement>
     <system>GitHub</system>
-    <url>https://github.com/google/google-http-java-client/issues</url>
+    <url>https://github.com/googleapis/google-http-java-client/issues</url>
   </issueManagement>
 
   <inceptionYear>2011</inceptionYear>
 
   <prerequisites>
-    <maven>2.0.9</maven>
+    <maven>3.5.4</maven>
   </prerequisites>
 
   <scm>
-    <connection>scm:git:https://github.com/google/google-http-java-client.git</connection>
-    <developerConnection>scm:git:git@github.com:google/google-http-java-client.git</developerConnection>
-    <url>https://github.com/google/google-http-java-client</url>
+    <connection>scm:git:https://github.com/googleapis/google-http-java-client.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/google-http-java-client.git</developerConnection>
+    <url>https://github.com/googleapis/google-http-java-client</url>
   </scm>
 
   <organization>

--- a/samples/dailymotion-simple-cmdline-sample/instructions.html
+++ b/samples/dailymotion-simple-cmdline-sample/instructions.html
@@ -7,9 +7,9 @@
 
 <ul>
   <li><a
-    href="http://code.google.com/p/google-http-java-client/source/browse?repo=samples#hg/dailymotion-simple-cmdline-sample">Browse
+    href="https://github.com/googleapis/google-http-java-client/tree/master/samples/dailymotion-simple-cmdline-sample">Browse
   Source</a>, or main file <a
-    href="http://code.google.com/p/google-http-java-client/source/browse/dailymotion-simple-cmdline-sample/src/main/java/com/google/api/services/samples/dailymotion/cmdline/simple/DailyMotionSample.java?repo=samples">DailyMotionSample.java</a></li>
+    href="https://github.com/googleapis/google-http-java-client/blob/master/samples/dailymotion-simple-cmdline-sample/src/main/java/com/google/api/services/samples/dailymotion/cmdline/simple/DailyMotionSample.java">DailyMotionSample.java</a></li>
 </ul>
 
 <h3>Checkout Instructions</h3>
@@ -20,7 +20,7 @@
 your <code>JAVA_HOME</code>.</p>
 
 <pre><code>cd <i>[someDirectory]</i>
-hg clone https://code.google.com/p/google-http-java-client.samples/ google-http-java-client-samples
+git clone https://github.com/googleapis/google-http-java-client
 cd google-http-java-client-samples/dailymotion-simple-cmdline-sample
 mvn compile
 mvn -q exec:java</code></pre>

--- a/samples/googleplus-simple-cmdline-sample/instructions.html
+++ b/samples/googleplus-simple-cmdline-sample/instructions.html
@@ -7,16 +7,16 @@
 
   <ul>
     <li><a
-      href="http://code.google.com/p/google-http-java-client/source/browse?repo=samples#hg/googleplus-simple-cmdline-sample">Browse
+      href="https://github.com/googleapis/google-http-java-client/tree/master/samples/googleplus-simple-cmdline-sample">Browse
         Source</a>, or main file <a
-      href="http://code.google.com/p/google-http-java-client/source/browse/googleplus-simple-cmdline-sample/src/main/java/com/google/api/services/samples/googleplus/cmdline/simple/GooglePlusSample.java?repo=samples">GooglePlusSample.java</a>
+      href="https://github.com/googleapis/google-http-java-client/blob/master/samples/googleplus-simple-cmdline-sample/src/main/java/com/google/api/services/samples/googleplus/cmdline/simple/GooglePlusSample.java">GooglePlusSample.java</a>
     </li>
   </ul>
 
   <h3>Register Your Application</h3>
 
   <ul>
-    <li>Visit the <a href="https://code.google.com/apis/console/?api=plus">Google
+    <li>Visit the <a href="https://console.cloud.google.com/">Google
         apis console</a>
     </li>
     <li>If this is the first you run the sample...</li>
@@ -31,7 +31,7 @@
   <h3>Checkout Instructions</h3>
 
   <p>
-    <b>Prerequisites:</b> install <a href="http://java.com">Java 6</a>, <a
+    <b>Prerequisites:</b> install <a href="http://java.com">Java 6+</a>, <a
       href="http://mercurial.selenic.com/">Mercurial</a> and <a
       href="http://maven.apache.org/download.html">Maven</a>. You may need to
     set your
@@ -41,7 +41,7 @@
 
   <pre>
     <code>cd <i>[someDirectory]</i>
-hg clone https://code.google.com/p/google-http-java-client.samples/ google-http-java-client-samples
+git clone https://github.com/googleapis/google-http-java-client
 cd google-http-java-client-samples/googleplus-simple-cmdline-sample
 mvn compile
 mvn -q exec:java</code>

--- a/samples/googleplus-simple-cmdline-sample/src/main/java/com/google/api/services/samples/googleplus/cmdline/simple/GooglePlusSample.java
+++ b/samples/googleplus-simple-cmdline-sample/src/main/java/com/google/api/services/samples/googleplus/cmdline/simple/GooglePlusSample.java
@@ -33,13 +33,13 @@ import java.util.List;
 
 /**
  * Simple example that demonstrates how to use <a
- * href="code.google.com/p/google-http-java-client/">Google HTTP Client Library for Java</a> with
+ * href="https://github.com/googleapis/google-http-java-client">Google HTTP Client Library for Java</a> with
  * the <a href="https://developers.google.com/+/api/">Google+ API</a>.
  *
  * <p>
  * Note that in the case of the Google+ API, there is a much better custom library built on top of
  * this HTTP library that is much easier to use and hides most of these details for you. See <a
- * href="http://code.google.com/p/google-api-java-client/wiki/APIs#Google+_API">Google+ API for
+ * href="https://developers.google.com/api-client-library/java/apis/plus/v1">Google+ API for
  * Java</a>.
  * </p>
  *
@@ -48,7 +48,7 @@ import java.util.List;
 public class GooglePlusSample {
 
   private static final String API_KEY =
-      "Enter API Key from https://code.google.com/apis/console/?api=plus into API_KEY";
+      "Enter API Key from https://console.cloud.google.com/apis/api/plus.googleapis.com/overview into API_KEY";
 
   private static final String USER_ID = "116899029375914044550";
   private static final int MAX_RESULTS = 3;


### PR DESCRIPTION
Fixes #468 (the few left are still working, and the others have nowhere to go right now - appengine-sdk code doesn't appear available on GitHub).
Fixes #469 