### PR TITLE
add patch to google http client

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpTransport.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpTransport.java
@@ -35,6 +35,7 @@ import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -209,6 +210,8 @@ public final class ApacheHttpTransport extends HttpTransport {
       requestBase = new HttpGet(url);
     } else if (method.equals(HttpMethods.HEAD)) {
       requestBase = new HttpHead(url);
+    } else if (method.equals(HttpMethods.PATCH)) {
+      requestBase = new HttpPatch(url);
     } else if (method.equals(HttpMethods.POST)) {
       requestBase = new HttpPost(url);
     } else if (method.equals(HttpMethods.PUT)) {

--- a/google-http-client/src/test/java/com/google/api/client/http/apache/ApacheHttpTransportTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/apache/ApacheHttpTransportTest.java
@@ -73,6 +73,8 @@ public class ApacheHttpTransportTest extends TestCase {
     subtestUnsupportedRequestsWithContent(
         transport.buildRequest("HEAD", "http://www.test.url"), "HEAD");
 
+    // Test PATCH.
+    execute(transport.buildRequest("PATCH", "http://www.test.url"));
     // Test PUT.
     execute(transport.buildRequest("PUT", "http://www.test.url"));
     // Test POST.


### PR DESCRIPTION
Adds support for HTTP PATCH method using the apache client.

- [x] Tests pass
- [x] Appropriate docs were updated (if necessary)
