### PR TITLE
Release v1.26.0

### DIFF
--- a/google-http-client-android-test/pom.xml
+++ b/google-http-client-android-test/pom.xml
@@ -4,7 +4,7 @@
   <groupId>google-http-client</groupId>
   <artifactId>google-http-client-android-test</artifactId>
   <name>Test project for google-http-client-android.</name>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-android-test:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-android-test:current} -->
   <packaging>apk</packaging>
 
   <build>

--- a/google-http-client-android/pom.xml
+++ b/google-http-client-android/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-android</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-android:current} -->
   <name>Android Platform Extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-appengine/pom.xml
+++ b/google-http-client-appengine/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-appengine</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-appengine:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-appengine:current} -->
   <name>Google App Engine extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-assembly/pom.xml
+++ b/google-http-client-assembly/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-assembly</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-assembly:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-assembly:current} -->
   <packaging>pom</packaging>
   <name>Assembly for the Google HTTP Client Library for Java</name>
 

--- a/google-http-client-findbugs/pom.xml
+++ b/google-http-client-findbugs/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-findbugs</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-findbugs:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-findbugs:current} -->
   <name>Google APIs Client Library Findbugs custom plugin.</name>
 
   <build>

--- a/google-http-client-gson/pom.xml
+++ b/google-http-client-gson/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-gson</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-gson:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-gson:current} -->
   <name>GSON extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-jackson/pom.xml
+++ b/google-http-client-jackson/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jackson</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-jackson:current} -->
   <name>Jackson extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-jackson2/pom.xml
+++ b/google-http-client-jackson2/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jackson2</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson2:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-jackson2:current} -->
   <name>Jackson 2 extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-jdo/pom.xml
+++ b/google-http-client-jdo/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jdo</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-jdo:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-jdo:current} -->
   <name>JDO extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-protobuf/pom.xml
+++ b/google-http-client-protobuf/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-protobuf</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-protobuf:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-protobuf:current} -->
   <name>Protocol Buffer extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-test/pom.xml
+++ b/google-http-client-test/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-test</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-test:current} -->
   <name>Shared classes used for testing of artifacts in the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-xml/pom.xml
+++ b/google-http-client-xml/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-xml</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-xml:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-xml:current} -->
   <name>XML extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client:current} -->
   <name>Google HTTP Client Library for Java</name>
   <description>
     Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-parent</artifactId>
-  <version>1.26.0-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+  <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google HTTP Client Library for Java</name>
 

--- a/samples/dailymotion-simple-cmdline-sample/pom.xml
+++ b/samples/dailymotion-simple-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>dailymotion-simple-cmdline-sample</artifactId>

--- a/samples/googleplus-simple-cmdline-sample/pom.xml
+++ b/samples/googleplus-simple-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.0-SNAPSHOT</version>
+    <version>1.26.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>googleplus-simple-cmdline-sample</artifactId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,17 +1,17 @@
 # Format:
 # module:released-version:current-version
 
-google-http-client:1.25.0:1.26.0-SNAPSHOT
-google-http-client-parent:1.25.0:1.26.0-SNAPSHOT
-google-http-client-android:1.25.0:1.26.0-SNAPSHOT
-google-http-client-android-test:1.25.0:1.26.0-SNAPSHOT
-google-http-client-appengine:1.25.0:1.26.0-SNAPSHOT
-google-http-client-assembly:1.25.0:1.26.0-SNAPSHOT
-google-http-client-findbugs:1.25.0:1.26.0-SNAPSHOT
-google-http-client-gson:1.25.0:1.26.0-SNAPSHOT
-google-http-client-jackson:1.25.0:1.26.0-SNAPSHOT
-google-http-client-jackson2:1.25.0:1.26.0-SNAPSHOT
-google-http-client-jdo:1.25.0:1.26.0-SNAPSHOT
-google-http-client-protobuf:1.25.0:1.26.0-SNAPSHOT
-google-http-client-test:1.25.0:1.26.0-SNAPSHOT
-google-http-client-xml:1.25.0:1.26.0-SNAPSHOT
+google-http-client:1.26.0:1.26.0
+google-http-client-parent:1.26.0:1.26.0
+google-http-client-android:1.26.0:1.26.0
+google-http-client-android-test:1.26.0:1.26.0
+google-http-client-appengine:1.26.0:1.26.0
+google-http-client-assembly:1.26.0:1.26.0
+google-http-client-findbugs:1.26.0:1.26.0
+google-http-client-gson:1.26.0:1.26.0
+google-http-client-jackson:1.26.0:1.26.0
+google-http-client-jackson2:1.26.0:1.26.0
+google-http-client-jdo:1.26.0:1.26.0
+google-http-client-protobuf:1.26.0:1.26.0
+google-http-client-test:1.26.0:1.26.0
+google-http-client-xml:1.26.0:1.26.0


### PR DESCRIPTION
This pull request was generated using releasetool.

10-12-2018 14:59 PDT

### Implementation Changes
- Fix test to run on environments with German locale ([#473](https://github.com/googleapis/google-http-java-client/pull/473)) ([#474](https://github.com/googleapis/google-http-java-client/pull/474))
- Fix throwIfFalseEOF if skip method was called before read ([#447](https://github.com/googleapis/google-http-java-client/pull/447))
- Fix arraymap iterator remove issue ([#371](https://github.com/googleapis/google-http-java-client/pull/371))

### New Features
- XML Parsing: Enum as element type ([#475](https://github.com/googleapis/google-http-java-client/pull/475)) ([#476](https://github.com/googleapis/google-http-java-client/pull/476))
- Add patch to google http client ([#486](https://github.com/googleapis/google-http-java-client/pull/486))
- Include Automatic-Module-Name in MANIFEST.MF ([#400](https://github.com/googleapis/google-http-java-client/pull/400))

### Dependencies
- Update test library versions ([#481](https://github.com/googleapis/google-http-java-client/pull/481))
- Update app engine SDK ([#467](https://github.com/googleapis/google-http-java-client/pull/467))

### Documentation
- Add the ending Java 6 support notice to README ([#483](https://github.com/googleapis/google-http-java-client/pull/483))
- Fix API doc links ([#479](https://github.com/googleapis/google-http-java-client/pull/479))
- Fix code.google.com links. Fix maven version ([#471](https://github.com/googleapis/google-http-java-client/pull/471))

### Internal / Testing Changes
- Enable releasetool for this project ([#488](https://github.com/googleapis/google-http-java-client/pull/488))
- Fix CODEOWNERS path
- Kokoro release jobs ([#472](https://github.com/googleapis/google-http-java-client/pull/472))
- Add CODEOWNERS and issue/pr templates ([#470](https://github.com/googleapis/google-http-java-client/pull/470))
- Add Kokoro continuous integration config and badges ([#465](https://github.com/googleapis/google-http-java-client/pull/465))
- Remove obsolete files ([#466](https://github.com/googleapis/google-http-java-client/pull/466))
- Fix compilation for Java 10 ([#454](https://github.com/googleapis/google-http-java-client/pull/454))
- Add Kokoro CI config ([#451](https://github.com/googleapis/google-http-java-client/pull/451))
