### PR TITLE
Revert "add patch to google http client (#486)"

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpTransport.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpTransport.java
@@ -35,7 +35,6 @@ import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -210,8 +209,6 @@ public final class ApacheHttpTransport extends HttpTransport {
       requestBase = new HttpGet(url);
     } else if (method.equals(HttpMethods.HEAD)) {
       requestBase = new HttpHead(url);
-    } else if (method.equals(HttpMethods.PATCH)) {
-      requestBase = new HttpPatch(url);
     } else if (method.equals(HttpMethods.POST)) {
       requestBase = new HttpPost(url);
     } else if (method.equals(HttpMethods.PUT)) {

--- a/google-http-client/src/test/java/com/google/api/client/http/apache/ApacheHttpTransportTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/apache/ApacheHttpTransportTest.java
@@ -73,8 +73,6 @@ public class ApacheHttpTransportTest extends TestCase {
     subtestUnsupportedRequestsWithContent(
         transport.buildRequest("HEAD", "http://www.test.url"), "HEAD");
 
-    // Test PATCH.
-    execute(transport.buildRequest("PATCH", "http://www.test.url"));
     // Test PUT.
     execute(transport.buildRequest("PUT", "http://www.test.url"));
     // Test POST.


### PR DESCRIPTION
This reverts commit 1f067daec8ab7871e9fce53398220e621c7642ae.

We need to revert this until we can upgrade Apache httpclient internally for android.