### PR TITLE
guava is not provided

### DIFF
--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -142,7 +142,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Fixes #502)

- [x] Tests pass
- [x] Appropriate docs were updated (if necessary)

There are some failing tests that don't seem related. Looking into those though:


Failed tests: 
```
  HttpRequestTest.testExecute_curlLogger:1199 expected:<...P-Java-Client/1.26.0[-SNAPSHOT] (gzip)' -- 'http://...> but was:<...P-Java-Client/1.26.0[] (gzip)' -- 'http://...>
  HttpRequestTest.testExecute_curlLoggerWithContentEncoding:1230 expected:<...P-Java-Client/1.26.0[-SNAPSHOT] (gzip)' -H 'Content...> but was:<...P-Java-Client/1.26.0[] (gzip)' -H 'Content...>
  HttpRequestTest.testExecute_headerSerialization:961 expected:<[foo Google-HTTP-Java-Client/1.26.0-SNAPSHOT (gzip)]> but was:<[foo Google-HTTP-Java-Client/1.26.0 (gzip)]>
  HttpRequestTest.testSuppressUserAgentSuffix:1111 expected:<...P-Java-Client/1.26.0[-SNAPSHOT] (gzip)> but was:<...P-Java-Client/1.26.0[] (gzip)>
  HttpRequestTest.testUserAgentWithExecuteErrorAndIOExceptionHandler:630 expected:<...P-Java-Client/1.26.0[-SNAPSHOT] (gzip)> but was:<...P-Java-Client/1.26.0[] (gzip)>
  HttpRequestTest.testUserAgentWithExecuteErrorAndRetryEnabled:614 expected:<...P-Java-Client/1.26.0[-SNAPSHOT] (gzip)> but was:<...P-Java-Client/1.26.0[] (gzip)>

```