### PR TITLE
Release google-http-java-client v1.27.0

### DIFF
--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -22,7 +22,7 @@ pushd $(dirname "$0")/../../
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-mvn clean install deploy \
+mvn clean install deploy -B \
   --settings settings.xml \
   -DperformRelease=true \
   -Dgpg.executable=gpg \

--- a/google-http-client-android-test/pom.xml
+++ b/google-http-client-android-test/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-android</artifactId>
-      <version>1.26.0-1.26.0</version>
+      <version>1.27.0</version><!-- {x-version-update:google-http-client-android:current} -->
       <exclusions>
         <exclusion>
           <artifactId>android</artifactId>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-test</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version><!-- {x-version-update:google-http-client-test:current} -->
       <exclusions>
         <exclusion>
           <artifactId>junit</artifactId>

--- a/google-http-client-android-test/pom.xml
+++ b/google-http-client-android-test/pom.xml
@@ -4,7 +4,7 @@
   <groupId>google-http-client</groupId>
   <artifactId>google-http-client-android-test</artifactId>
   <name>Test project for google-http-client-android.</name>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-android-test:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-android-test:current} -->
   <packaging>apk</packaging>
 
   <build>

--- a/google-http-client-android/pom.xml
+++ b/google-http-client-android/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-android</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-android:current} -->
   <name>Android Platform Extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-appengine/pom.xml
+++ b/google-http-client-appengine/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-appengine</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-appengine:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-appengine:current} -->
   <name>Google App Engine extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-assembly/pom.xml
+++ b/google-http-client-assembly/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-assembly</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-assembly:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-assembly:current} -->
   <packaging>pom</packaging>
   <name>Assembly for the Google HTTP Client Library for Java</name>
 

--- a/google-http-client-bom/README.md
+++ b/google-http-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-bom</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-http-client-bom/pom.xml
+++ b/google-http-client-bom/pom.xml
@@ -16,6 +16,18 @@
     <name>Google LLC</name>
   </organization>
 
+  <developers>
+    <developer>
+      <id>chingor13</id>
+      <name>Jeff Ching</name>
+      <email>chingor@google.com</email>
+      <organization>Google LLC</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
+
   <scm>
     <connection>scm:git:https://github.com/googleapis/google-http-java-client.git</connection>
     <developerConnection>scm:git:git@github.com:googleapis/google-http-java-client.git</developerConnection>

--- a/google-http-client-bom/pom.xml
+++ b/google-http-client-bom/pom.xml
@@ -110,4 +110,55 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.6</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>sonatype-nexus-staging</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>false</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>release-sign-artifacts</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/google-http-client-bom/pom.xml
+++ b/google-http-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-bom</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-bom:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-bom:current} -->
   <packaging>pom</packaging>
 
   <name>Google HTTP Client Library for Java BOM</name>
@@ -51,62 +51,62 @@
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-android</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client-android:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-appengine</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-appengine:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client-appengine:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-assembly</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-assembly:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client-assembly:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-findbugs</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-findbugs:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client-findbugs:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-gson</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-gson:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client-gson:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-jackson</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client-jackson:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-jackson2</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson2:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client-jackson2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-jdo</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jdo:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client-jdo:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-protobuf</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-protobuf:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client-protobuf:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-test</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client-test:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-xml</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-xml:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-http-client-xml:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-http-client-findbugs/pom.xml
+++ b/google-http-client-findbugs/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-findbugs</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-findbugs:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-findbugs:current} -->
   <name>Google APIs Client Library Findbugs custom plugin.</name>
 
   <build>

--- a/google-http-client-gson/pom.xml
+++ b/google-http-client-gson/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-gson</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-gson:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-gson:current} -->
   <name>GSON extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-jackson/pom.xml
+++ b/google-http-client-jackson/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jackson</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-jackson:current} -->
   <name>Jackson extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-jackson2/pom.xml
+++ b/google-http-client-jackson2/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jackson2</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson2:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-jackson2:current} -->
   <name>Jackson 2 extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-jdo/pom.xml
+++ b/google-http-client-jdo/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jdo</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jdo:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-jdo:current} -->
   <name>JDO extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-protobuf/pom.xml
+++ b/google-http-client-protobuf/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-protobuf</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-protobuf:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-protobuf:current} -->
   <name>Protocol Buffer extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-test/pom.xml
+++ b/google-http-client-test/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-test</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-test:current} -->
   <name>Shared classes used for testing of artifacts in the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-xml/pom.xml
+++ b/google-http-client-xml/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-xml</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-xml:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-xml:current} -->
   <name>XML extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client:current} -->
   <name>Google HTTP Client Library for Java</name>
   <description>
     Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -50,7 +50,7 @@ public final class HttpRequest {
    *
    * @since 1.8
    */
-  public static final String VERSION = "1.26.0";
+  public static final String VERSION = "1.27.0"; // {x-version-update:google-http-client-parent:current}
 
   /**
    * User agent suffix for all requests.

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -50,7 +50,7 @@ public final class HttpRequest {
    *
    * @since 1.8
    */
-  public static final String VERSION = "1.27.0"; // {x-version-update:google-http-client-parent:current}
+  public static final String VERSION = "1.27.0";
 
   /**
    * User agent suffix for all requests.

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -505,7 +505,7 @@ public final class HttpRequest {
    * By default it is 0 (infinite).
    * </p>
    *
-   * @since 1.26
+   * @since 1.27
    */
   public int getWriteTimeout() {
     return writeTimeout;
@@ -514,7 +514,7 @@ public final class HttpRequest {
   /**
    * Sets the timeout in milliseconds to send POST/PUT data or {@code 0} for an infinite timeout.
    *
-   * @since 1.26
+   * @since 1.27
    */
   public HttpRequest setWriteTimeout(int writeTimeout) {
     Preconditions.checkArgument(writeTimeout >= 0);

--- a/google-http-client/src/main/java/com/google/api/client/http/LowLevelHttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/LowLevelHttpRequest.java
@@ -169,7 +169,7 @@ public abstract class LowLevelHttpRequest {
    * @param writeTimeout timeout in milliseconds to establish a connection or {@code 0} for an
    *        infinite timeout
    * @throws IOException I/O exception
-   * @since 1.26
+   * @since 1.27
    */
   public void setWriteTimeout(int writeTimeout) throws IOException {
   }

--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
     <module>google-http-client-assembly</module>
     <module>google-http-client-appengine</module>
     <module>google-http-client-android</module>
-    <module>google-http-client-bom</module>
     <module>google-http-client-protobuf</module>
     <module>google-http-client-gson</module>
     <module>google-http-client-jackson</module>
     <module>google-http-client-jackson2</module>
     <module>google-http-client-jdo</module>
+    <module>google-http-client-xml</module>
 
     <module>google-http-client-findbugs</module>
     <module>google-http-client-test</module>
@@ -74,7 +74,7 @@
     <module>samples/googleplus-simple-cmdline-sample</module>
 
     <!-- A deployable artifact must be last or deploys are skipped -->
-    <module>google-http-client-xml</module>
+    <module>google-http-client-bom</module>
   </modules>
 
   <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,10 @@
           </configuration>
         </plugin>
         <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>jarjar-maven-plugin</artifactId>
           <version>1.9</version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-parent</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google HTTP Client Library for Java</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
     <module>google-http-client-assembly</module>
     <module>google-http-client-appengine</module>
     <module>google-http-client-android</module>
+    <module>google-http-client-bom</module>
     <module>google-http-client-protobuf</module>
     <module>google-http-client-gson</module>
     <module>google-http-client-jackson</module>
     <module>google-http-client-jackson2</module>
     <module>google-http-client-jdo</module>
-    <module>google-http-client-xml</module>
 
     <module>google-http-client-findbugs</module>
     <module>google-http-client-test</module>
@@ -74,7 +74,7 @@
     <module>samples/googleplus-simple-cmdline-sample</module>
 
     <!-- A deployable artifact must be last or deploys are skipped -->
-    <module>google-http-client-bom</module>
+    <module>google-http-client-xml</module>
   </modules>
 
   <pluginRepositories>

--- a/samples/dailymotion-simple-cmdline-sample/pom.xml
+++ b/samples/dailymotion-simple-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>dailymotion-simple-cmdline-sample</artifactId>

--- a/samples/googleplus-simple-cmdline-sample/pom.xml
+++ b/samples/googleplus-simple-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>googleplus-simple-cmdline-sample</artifactId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,18 +1,18 @@
 # Format:
 # module:released-version:current-version
 
-google-http-client:1.26.0:1.26.1-SNAPSHOT
-google-http-client-bom:1.26.0:1.26.1-SNAPSHOT
-google-http-client-parent:1.26.0:1.26.1-SNAPSHOT
-google-http-client-android:1.26.0:1.26.1-SNAPSHOT
-google-http-client-android-test:1.26.0:1.26.1-SNAPSHOT
-google-http-client-appengine:1.26.0:1.26.1-SNAPSHOT
-google-http-client-assembly:1.26.0:1.26.1-SNAPSHOT
-google-http-client-findbugs:1.26.0:1.26.1-SNAPSHOT
-google-http-client-gson:1.26.0:1.26.1-SNAPSHOT
-google-http-client-jackson:1.26.0:1.26.1-SNAPSHOT
-google-http-client-jackson2:1.26.0:1.26.1-SNAPSHOT
-google-http-client-jdo:1.26.0:1.26.1-SNAPSHOT
-google-http-client-protobuf:1.26.0:1.26.1-SNAPSHOT
-google-http-client-test:1.26.0:1.26.1-SNAPSHOT
-google-http-client-xml:1.26.0:1.26.1-SNAPSHOT
+google-http-client:1.27.0:1.27.0
+google-http-client-bom:1.27.0:1.27.0
+google-http-client-parent:1.27.0:1.27.0
+google-http-client-android:1.27.0:1.27.0
+google-http-client-android-test:1.27.0:1.27.0
+google-http-client-appengine:1.27.0:1.27.0
+google-http-client-assembly:1.27.0:1.27.0
+google-http-client-findbugs:1.27.0:1.27.0
+google-http-client-gson:1.27.0:1.27.0
+google-http-client-jackson:1.27.0:1.27.0
+google-http-client-jackson2:1.27.0:1.27.0
+google-http-client-jdo:1.27.0:1.27.0
+google-http-client-protobuf:1.27.0:1.27.0
+google-http-client-test:1.27.0:1.27.0
+google-http-client-xml:1.27.0:1.27.0


### PR DESCRIPTION
This pull request was generated using releasetool.

11-09-2018 09:27 PST

### New Features
- Allow Enums in DataMaps ([#505](https://github.com/googleapis/google-http-java-client/pull/505))
- Add write timeout for post/put requests ([#485](https://github.com/googleapis/google-http-java-client/pull/485))
- Add google-http-client-bom artifact ([#517](https://github.com/googleapis/google-http-java-client/pull/517))

### Dependencies
- guava is not a regular dependency ([#508](https://github.com/googleapis/google-http-java-client/pull/508))
- Upgrade maven-javadoc-plugin to 3.0.1 ([#519](https://github.com/googleapis/google-http-java-client/pull/519))
- Set the version of the jarjar-maven-plugin in pluginManagement ([#515](https://github.com/googleapis/google-http-java-client/pull/515))

### Internal / Testing Changes
- Fix parameter of maven-javadoc-plugin ([#522](https://github.com/googleapis/google-http-java-client/pull/522)) ([#523](https://github.com/googleapis/google-http-java-client/pull/523))
- Skip Lint of JavaDoc ([#525](https://github.com/googleapis/google-http-java-client/pull/525))
- Fix broken snapshot and proto tests ([#512](https://github.com/googleapis/google-http-java-client/pull/512))
- Add Java 11 Kokoro config ([#487](https://github.com/googleapis/google-http-java-client/pull/487))
- Release improvements ([#501](https://github.com/googleapis/google-http-java-client/pull/501))
- Bump next snapshot ([#500](https://github.com/googleapis/google-http-java-client/pull/500))