### PR TITLE
Fix int type transformed as BigDecimal value when parsing as Map

### DIFF
--- a/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonFactoryTest.java
+++ b/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonFactoryTest.java
@@ -483,7 +483,7 @@ public abstract class AbstractJsonFactoryTest extends TestCase {
   static final String MAP_TYPE =
       "{\"value\":[{\"map1\":{\"k1\":1,\"k2\":2},\"map2\":{\"kk1\":3,\"kk2\":4}}]}";
   static final String BIGDECIMAL_MAP_TYPE =
-      "{\"value\":[{\"map1\":{\"k1\":1.14566,\"k2\":2.14786},\"map2\":{\"kk1\":3.29786,\"kk2\":4.69786}}]}";
+      "{\"value\":[{\"map1\":{\"k1\":1.14566,\"k2\":2.14},\"map2\":{\"kk1\":3.29,\"kk2\":4.69}}]}";
 
   public void testParser_mapType() throws Exception {
     // parse

--- a/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonFactoryTest.java
+++ b/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonFactoryTest.java
@@ -482,6 +482,8 @@ public abstract class AbstractJsonFactoryTest extends TestCase {
 
   static final String MAP_TYPE =
       "{\"value\":[{\"map1\":{\"k1\":1,\"k2\":2},\"map2\":{\"kk1\":3,\"kk2\":4}}]}";
+  static final String BIGDECIMAL_MAP_TYPE =
+          "{\"value\":[{\"map1\":{\"k1\":1.14566,\"k2\":2.14786},\"map2\":{\"kk1\":3.29786,\"kk2\":4.69786}}]}";
 
   public void testParser_mapType() throws Exception {
     // parse
@@ -510,16 +512,35 @@ public abstract class AbstractJsonFactoryTest extends TestCase {
     parser = factory.createJsonParser(MAP_TYPE);
     parser.nextToken();
     @SuppressWarnings("unchecked")
-    HashMap<String, ArrayList<ArrayMap<String, ArrayMap<String, BigDecimal>>>> result =
+    HashMap<String, ArrayList<ArrayMap<String, ArrayMap<String, Integer>>>> result =
         parser.parse(HashMap.class);
     // serialize
     assertEquals(MAP_TYPE, factory.toString(result));
     // check parsed result
+    ArrayList<ArrayMap<String, ArrayMap<String, Integer>>> value = result.get("value");
+    ArrayMap<String, ArrayMap<String, Integer>> firstMap = value.get(0);
+    ArrayMap<String, Integer> map1 = firstMap.get("map1");
+    Integer integer = map1.get("k1");
+    assertEquals(1, integer.intValue());
+  }
+
+  public void testParser_hashmapForMapTypeWithBigDecimal() throws Exception {
+    // parse
+    JsonFactory factory = newFactory();
+    JsonParser parser;
+    parser = factory.createJsonParser(BIGDECIMAL_MAP_TYPE);
+    parser.nextToken();
+    @SuppressWarnings("unchecked")
+    HashMap<String, ArrayList<ArrayMap<String, ArrayMap<String, BigDecimal>>>> result =
+        parser.parse(HashMap.class);
+    // serialize
+    assertEquals(BIGDECIMAL_MAP_TYPE, factory.toString(result));
+    // check parsed result
     ArrayList<ArrayMap<String, ArrayMap<String, BigDecimal>>> value = result.get("value");
     ArrayMap<String, ArrayMap<String, BigDecimal>> firstMap = value.get(0);
     ArrayMap<String, BigDecimal> map1 = firstMap.get("map1");
-    BigDecimal integer = map1.get("k1");
-    assertEquals(1, integer.intValue());
+    BigDecimal bigDecimal = map1.get("k1");
+    assertEquals(BigDecimal.valueOf(1.14566).setScale(5), bigDecimal);
   }
 
   public static class WildCardTypes {
@@ -547,8 +568,8 @@ public abstract class AbstractJsonFactoryTest extends TestCase {
     assertEquals(WILDCARD_TYPE, factory.toString(result));
     // check parsed result
     Collection<?>[] simple = result.simple;
-    ArrayList<BigDecimal> wildcard = (ArrayList<BigDecimal>) simple[0];
-    BigDecimal wildcardFirstValue = wildcard.get(0);
+    ArrayList<Integer> wildcard = (ArrayList<Integer>) simple[0];
+    Integer wildcardFirstValue = wildcard.get(0);
     assertEquals(1, wildcardFirstValue.intValue());
     Collection<? extends Integer>[] upper = result.upper;
     ArrayList<Integer> wildcardUpper = (ArrayList<Integer>) upper[0];
@@ -558,8 +579,8 @@ public abstract class AbstractJsonFactoryTest extends TestCase {
     ArrayList<Integer> wildcardLower = (ArrayList<Integer>) lower[0];
     Integer wildcardFirstValueLower = wildcardLower.get(0);
     assertEquals(1, wildcardFirstValueLower.intValue());
-    Map<String, BigDecimal> map = (Map<String, BigDecimal>) result.map;
-    BigDecimal mapValue = map.get("v");
+    Map<String, Integer> map = (Map<String, Integer>) result.map;
+    Integer mapValue = map.get("v");
     assertEquals(1, mapValue.intValue());
     Map<String, Integer> mapUpper = (Map<String, Integer>) result.mapUpper;
     Integer mapUpperValue = mapUpper.get("v");
@@ -771,16 +792,16 @@ public abstract class AbstractJsonFactoryTest extends TestCase {
     ArrayList<Object> arr = (ArrayList<Object>) result.get("arr");
     assertEquals(2, arr.size());
     assertEquals(Data.nullOf(Object.class), arr.get(0));
-    ArrayList<BigDecimal> subArr = (ArrayList<BigDecimal>) arr.get(1);
+    ArrayList<Integer> subArr = (ArrayList<Integer>) arr.get(1);
     assertEquals(2, subArr.size());
     assertEquals(Data.nullOf(Object.class), subArr.get(0));
-    BigDecimal arrValue = subArr.get(1);
+    Integer arrValue = subArr.get(1);
     assertEquals(1, arrValue.intValue());
     // null value
     Object nullValue = result.get("nullValue");
     assertEquals(Data.nullOf(Object.class), nullValue);
     // value
-    BigDecimal value = (BigDecimal) result.get("value");
+    Integer value = (Integer) result.get("value");
     assertEquals(1, value.intValue());
   }
 
@@ -1519,7 +1540,7 @@ public abstract class AbstractJsonFactoryTest extends TestCase {
     assertEquals(4, dog.numberOfLegs);
     assertEquals(3, ((DogGenericJson) dog).tricksKnown);
     assertEquals("this is not being used!", dog.get("unusedInfo"));
-    BigDecimal foo = ((BigDecimal) ((ArrayMap<String, Object>) dog.get("unused")).get("foo"));
+    Integer foo = ((Integer) ((ArrayMap<String, Object>) dog.get("unused")).get("foo"));
     assertEquals(200, foo.intValue());
   }
 

--- a/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonFactoryTest.java
+++ b/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonFactoryTest.java
@@ -483,7 +483,7 @@ public abstract class AbstractJsonFactoryTest extends TestCase {
   static final String MAP_TYPE =
       "{\"value\":[{\"map1\":{\"k1\":1,\"k2\":2},\"map2\":{\"kk1\":3,\"kk2\":4}}]}";
   static final String BIGDECIMAL_MAP_TYPE =
-          "{\"value\":[{\"map1\":{\"k1\":1.14566,\"k2\":2.14786},\"map2\":{\"kk1\":3.29786,\"kk2\":4.69786}}]}";
+      "{\"value\":[{\"map1\":{\"k1\":1.14566,\"k2\":2.14786},\"map2\":{\"kk1\":3.29786,\"kk2\":4.69786}}]}";
 
   public void testParser_mapType() throws Exception {
     // parse

--- a/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
@@ -828,6 +828,9 @@ public abstract class JsonParser implements Closeable {
           Preconditions.checkArgument(
               fieldContext == null || fieldContext.getAnnotation(JsonString.class) == null,
               "number type formatted as a JSON number cannot use @JsonString annotation");
+          if (getCurrentToken() == VALUE_NUMBER_INT && (valueClass == null || valueClass.isAssignableFrom(Integer.class))) {
+            return getIntValue();
+          }
           if (valueClass == null || valueClass.isAssignableFrom(BigDecimal.class)) {
             return getDecimalValue();
           }

--- a/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
@@ -828,7 +828,8 @@ public abstract class JsonParser implements Closeable {
           Preconditions.checkArgument(
               fieldContext == null || fieldContext.getAnnotation(JsonString.class) == null,
               "number type formatted as a JSON number cannot use @JsonString annotation");
-          if (getCurrentToken() == VALUE_NUMBER_INT && (valueClass == null || valueClass.isAssignableFrom(Integer.class))) {
+          if (getCurrentToken() == JsonToken.VALUE_NUMBER_INT
+              && (valueClass == null || valueClass.isAssignableFrom(Integer.class))) {
             return getIntValue();
           }
           if (valueClass == null || valueClass.isAssignableFrom(BigDecimal.class)) {


### PR DESCRIPTION
Using with Jackson2 parser,  a simple parsing of { "data" : 1} gives a BigDecimal instead an integer. In my case, ``valueClass`` is Object, but the JSON current token is VALUE_NUMBER_INT not FLOAT.

I parse as a Map. No problem if I parse as a class with "int" type.