### PR TITLE
Fix default charset for HttpRequest

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/AbstractHttpContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/AbstractHttpContent.java
@@ -98,7 +98,7 @@ public abstract class AbstractHttpContent implements HttpContent {
    */
   protected final Charset getCharset() {
     return mediaType == null || mediaType.getCharsetParameter() == null
-        ? Charsets.UTF_8 : mediaType.getCharsetParameter();
+        ? Charsets.ISO_8859_1 : mediaType.getCharsetParameter();
   }
 
   public String getType() {


### PR DESCRIPTION
Fixes #300 Request charset defaults to UTF-8, Response charset defaults to ISO_8859_1

- [ ] Tests pass
- [ ] Appropriate docs were updated (if necessary)
