### PR TITLE
Fix GenericUrl to decode path parts correctly

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
@@ -548,7 +548,7 @@ public class GenericUrl extends GenericData {
       } else {
         sub = encodedPath.substring(cur);
       }
-      result.add(CharEscapers.decodeUri(sub));
+      result.add(CharEscapers.decode(sub));
       cur = slash + 1;
     }
     return result;

--- a/google-http-client/src/main/java/com/google/api/client/util/escape/CharEscapers.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/escape/CharEscapers.java
@@ -103,8 +103,8 @@ public final class CharEscapers {
    * what characters are represented by any consecutive sequences of the form "%<i>XX</i>".
    *
    * <p>
-   * This doesnt replaces each occurrence of '+' with a space, ' '. So this method should not be used for
-   * application/x-www-form-urlencoded strings such as query.
+   * This doesnt replaces each occurrence of '+' with a space, ' '. So this method should not be
+   * used for application/x-www-form-urlencoded strings such as query.
    * </p>
    *
    * @param uri a percent-encoded US-ASCII string

--- a/google-http-client/src/main/java/com/google/api/client/util/escape/CharEscapers.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/escape/CharEscapers.java
@@ -15,6 +15,8 @@
 package com.google.api.client.util.escape;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLDecoder;
 
 /**
@@ -94,6 +96,32 @@ public final class CharEscapers {
       // UTF-8 encoding guaranteed to be supported by JVM
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Percent-decodes a US-ASCII string into a Unicode string. UTF-8 encoding is used to determine
+   * what characters are represented by any consecutive sequences of the form "%<i>XX</i>".
+   *
+   * <p>
+   * This doesnt replaces each occurrence of '+' with a space, ' '. So this method should not be used for
+   * application/x-www-form-urlencoded strings such as query.
+   * </p>
+   *
+   * @param uri a percent-encoded US-ASCII string
+   * @return a Unicode string
+   */
+  public static String decode(String uri) {
+    if (uri.indexOf('%') > -1) {
+      if (uri.indexOf('+') > -1) {
+        try {
+          return new URI(uri).getPath();
+        } catch (URISyntaxException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return decodeUri(uri);
+    }
+    return uri;
   }
 
   /**

--- a/google-http-client/src/test/java/com/google/api/client/http/GenericUrlTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/GenericUrlTest.java
@@ -475,6 +475,8 @@ public class GenericUrlTest extends TestCase {
     subtestToPathParts("/path/to/resource", "", "path", "to", "resource");
     subtestToPathParts("/path/to/resource/", "", "path", "to", "resource", "");
     subtestToPathParts("/Go%3D%23%2F%25%26%20?%3Co%3Egle/2nd", "", "Go=#/%& ?<o>gle", "2nd");
+    subtestToPathParts("/path+with+plus/2nd", "", "path+with+plus", "2nd");
+    subtestToPathParts("/path%2Bwith+plus/2nd", "", "path+with+plus", "2nd");
   }
 
   private void subtestToPathParts(String encodedPath, String... expectedDecodedParts) {


### PR DESCRIPTION
Fixes #398  GenericUrl converts plus sign into space within URI path component

- [ ] Tests pass
- [ ] Appropriate docs were updated (if necessary)
