### PR TITLE
Fix UriTemplate.expand to properly escape value

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/UriTemplate.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/UriTemplate.java
@@ -186,7 +186,7 @@ public class UriTemplate {
       String encodedValue;
       if (reservedExpansion) {
         // Reserved expansion allows pct-encoded triplets and characters in the reserved set.
-        encodedValue = CharEscapers.escapeUriPath(value);
+        encodedValue = CharEscapers.escapeUriPathWithoutReserved(value);
       } else {
         encodedValue = CharEscapers.escapeUri(value);
       }
@@ -339,26 +339,14 @@ public class UriTemplate {
           value = getListPropertyValue(varName, iterator, containsExplodeModifier, compositeOutput);
         } else if (value.getClass().isEnum()) {
           String name = FieldInfo.of((Enum<?>) value).getName();
-          if (name != null) {
-            if (compositeOutput.requiresVarAssignment()) {
-              value = String.format("%s=%s", varName, value);
-            }
-            value = CharEscapers.escapeUriPath(value.toString());
-          }
+          value = getSimpleValue(varName, name != null ? name : value.toString(), compositeOutput);
         } else if (!Data.isValueOfPrimitiveType(value)) {
           // Parse the value as a key/value map.
           Map<String, Object> map = getMap(value);
           value = getMapPropertyValue(varName, map, containsExplodeModifier, compositeOutput);
         } else {
           // For everything else...
-          if (compositeOutput.requiresVarAssignment()) {
-            value = String.format("%s=%s", varName, value);
-          }
-          if (compositeOutput.getReservedExpansion()) {
-            value = CharEscapers.escapeUriPathWithoutReserved(value.toString());
-          } else {
-            value = CharEscapers.escapeUriPath(value.toString());
-          }
+          value = getSimpleValue(varName, value.toString(), compositeOutput);
         }
         pathBuf.append(value);
       }
@@ -368,6 +356,13 @@ public class UriTemplate {
       GenericUrl.addQueryParams(variableMap.entrySet(), pathBuf);
     }
     return pathBuf.toString();
+  }
+
+  private static String getSimpleValue(String name, String value, CompositeOutput compositeOutput) {
+    if (compositeOutput.requiresVarAssignment()) {
+      return String.format("%s=%s", name, compositeOutput.getEncodedValue(value.toString()));
+    }
+    return compositeOutput.getEncodedValue(value);
   }
 
   /**

--- a/google-http-client/src/test/java/com/google/api/client/http/UriTemplateTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/UriTemplateTest.java
@@ -15,7 +15,6 @@
 package com.google.api.client.http;
 
 import com.google.api.client.util.Value;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.util.Arrays;

--- a/google-http-client/src/test/java/com/google/api/client/http/UriTemplateTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/UriTemplateTest.java
@@ -15,6 +15,7 @@
 package com.google.api.client.http;
 
 import com.google.api.client.util.Value;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.util.Arrays;
@@ -55,6 +56,13 @@ public class UriTemplateTest extends TestCase {
     assertTrue(requestMap.containsKey("abc"));
     assertTrue(requestMap.containsKey("def"));
     assertTrue(requestMap.containsKey("unused"));
+  }
+
+  public void testExpanTemplates_basicEncodeValue() {
+    SortedMap<String, Object> requestMap = Maps.newTreeMap();
+    requestMap.put("abc", "xyz;def");
+    assertEquals(";abc=xyz%3Bdef", UriTemplate.expand("{;abc}", requestMap, false));
+    assertEquals("xyz;def", UriTemplate.expand("{+abc}", requestMap, false));
   }
 
   public void testExpandTemplates_noExpansionsWithQueryParams() {


### PR DESCRIPTION
Fixes #351  UriTemplate.expand does not properly escape characters for path-style parameter expansion

- [ ] Tests pass
- [ ] Appropriate docs were updated (if necessary)
