### PR TITLE
Fix to build HttpResponseException when charset is malformed

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponseException.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponseException.java
@@ -18,6 +18,7 @@ import com.google.api.client.util.Preconditions;
 import com.google.api.client.util.StringUtils;
 
 import java.io.IOException;
+import java.nio.charset.IllegalCharsetNameException;
 
 /**
  * Exception thrown when an error status code is detected in an HTTP response.
@@ -176,8 +177,10 @@ public class HttpResponseException extends IOException {
         if (content.length() == 0) {
           content = null;
         }
-      } catch (IOException exception) {
+      } catch (IOException  exception) {
         // it would be bad to throw an exception while throwing an exception
+        exception.printStackTrace();
+      } catch (IllegalCharsetNameException exception) {
         exception.printStackTrace();
       }
       // message

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponseException.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponseException.java
@@ -18,7 +18,6 @@ import com.google.api.client.util.Preconditions;
 import com.google.api.client.util.StringUtils;
 
 import java.io.IOException;
-import java.nio.charset.IllegalCharsetNameException;
 
 /**
  * Exception thrown when an error status code is detected in an HTTP response.

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponseException.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponseException.java
@@ -177,10 +177,10 @@ public class HttpResponseException extends IOException {
         if (content.length() == 0) {
           content = null;
         }
-      } catch (IOException  exception) {
+      } catch (IOException exception) {
         // it would be bad to throw an exception while throwing an exception
         exception.printStackTrace();
-      } catch (IllegalCharsetNameException exception) {
+      } catch (IllegalArgumentException exception) {
         exception.printStackTrace();
       }
       // message

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpResponseExceptionTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpResponseExceptionTest.java
@@ -183,6 +183,62 @@ public class HttpResponseExceptionTest extends TestCase {
     }
   }
 
+  public void testInvalidCharset() throws Exception {
+    HttpTransport transport = new MockHttpTransport() {
+      @Override
+      public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+        return new MockLowLevelHttpRequest() {
+          @Override
+          public LowLevelHttpResponse execute() throws IOException {
+            MockLowLevelHttpResponse result = new MockLowLevelHttpResponse();
+            result.setStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+            result.setReasonPhrase("Not Found");
+            result.setContentType("text/plain; charset=");
+            result.setContent("Unable to find resource");
+            return result;
+          }
+        };
+      }
+    };
+    HttpRequest request =
+        transport.createRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
+    try {
+      request.execute();
+      fail();
+    } catch (HttpResponseException e) {
+      assertEquals(
+          "404 Not Found", e.getMessage());
+    }
+  }
+
+  public void testUnsupportedCharset() throws Exception {
+    HttpTransport transport = new MockHttpTransport() {
+      @Override
+      public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+        return new MockLowLevelHttpRequest() {
+          @Override
+          public LowLevelHttpResponse execute() throws IOException {
+            MockLowLevelHttpResponse result = new MockLowLevelHttpResponse();
+            result.setStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+            result.setReasonPhrase("Not Found");
+            result.setContentType("text/plain; charset=invalid-charset");
+            result.setContent("Unable to find resource");
+            return result;
+          }
+        };
+      }
+    };
+    HttpRequest request =
+        transport.createRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
+    try {
+      request.execute();
+      fail();
+    } catch (HttpResponseException e) {
+      assertEquals(
+          "404 Not Found", e.getMessage());
+    }
+  }
+
   public void testSerialization() throws Exception {
     HttpTransport transport = new MockHttpTransport();
     HttpRequest request =


### PR DESCRIPTION
Fixes #323 IllegalCharsetNameException in HttpResponse getContentCharset() if charset is malformed

- [ ] Tests pass
- [ ] Appropriate docs were updated (if necessary)
