### PR TITLE
Make signature of com.google.api.client.util.Data#nullOf more type safe

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/Data.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Data.java
@@ -107,7 +107,7 @@ public class Data {
    * @return magic object instance that represents the "null" value (not Java {@code null})
    * @throws IllegalArgumentException if unable to create a new instance
    */
-  public static <T> T nullOf(Class<?> objClass) {
+  public static <T> T nullOf(Class<T> objClass) {
     Object result = NULL_CACHE.get(objClass);
     if (result == null) {
       synchronized (NULL_CACHE) {


### PR DESCRIPTION
Fixes #273 

This PR makes signature of com.google.api.client.util.Data#nullOf more type safe so that it fails compile time check when somebody tries to use as ```Double obj = Data.nullOf(Integer.class);```

- [ ] Tests pass
- [ ] Appropriate docs were updated (if necessary)
