### PR TITLE
Implement Closeable & Flushable in JsonGenerator and JsonParser

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/json/JsonGenerator.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/JsonGenerator.java
@@ -22,6 +22,8 @@ import com.google.api.client.util.GenericData;
 import com.google.api.client.util.Preconditions;
 import com.google.api.client.util.Types;
 
+import java.io.Closeable;
+import java.io.Flushable;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
@@ -39,7 +41,7 @@ import java.util.Map;
  * @since 1.3
  * @author Yaniv Inbar
  */
-public abstract class JsonGenerator {
+public abstract class JsonGenerator implements Closeable, Flushable {
 
   /** Returns the JSON factory from which this generator was created. */
   public abstract JsonFactory getFactory();

--- a/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
@@ -24,6 +24,8 @@ import com.google.api.client.util.Preconditions;
 import com.google.api.client.util.Sets;
 import com.google.api.client.util.Types;
 
+import java.io.Closeable;
+import java.io.Flushable;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -60,7 +62,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @since 1.3
  * @author Yaniv Inbar
  */
-public abstract class JsonParser {
+public abstract class JsonParser implements Closeable, Flushable {
 
   /**
    * Maps a polymorphic {@link Class} to its {@link Field} with the {@link JsonPolymorphicTypeMap}

--- a/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
@@ -25,7 +25,6 @@ import com.google.api.client.util.Sets;
 import com.google.api.client.util.Types;
 
 import java.io.Closeable;
-import java.io.Flushable;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -62,7 +61,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @since 1.3
  * @author Yaniv Inbar
  */
-public abstract class JsonParser implements Closeable, Flushable {
+public abstract class JsonParser implements Closeable {
 
   /**
    * Maps a polymorphic {@link Class} to its {@link Field} with the {@link JsonPolymorphicTypeMap}


### PR DESCRIPTION
Fixes #342 JsonGenerator and JsonParser should implement Closeable (and Flushable) 

- [ ] Tests pass
- [ ] Appropriate docs were updated (if necessary)
