### PR TITLE
Deprecate AndroidHttp compatibility shim

### DIFF
--- a/google-http-client-android/src/main/java/com/google/api/client/extensions/android/http/AndroidHttp.java
+++ b/google-http-client-android/src/main/java/com/google/api/client/extensions/android/http/AndroidHttp.java
@@ -28,8 +28,11 @@ import java.net.HttpURLConnection;
  *
  * @since 1.11
  * @author Yaniv Inbar
+ * @deprecated Gingerbread is no longer supported by Google Play Services. Please use
+ *   {@link NetHttpTransport} directly or switch to Cronet which is better supported.
  */
 @Beta
+@Deprecated
 public class AndroidHttp {
 
   /**


### PR DESCRIPTION
This is a beta API that should no longer be necessary. Gingerbread is no longer supported by Google Play Services so this could only be useful for someone building an extremely legacy app (and they would need to use an earlier version anyways).
