### PR TITLE
Compile to Java 1.7 binary

### DIFF
--- a/google-http-client-android/pom.xml
+++ b/google-http-client-android/pom.xml
@@ -17,7 +17,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/google-http-client-appengine/pom.xml
+++ b/google-http-client-appengine/pom.xml
@@ -43,7 +43,7 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
+            <artifactId>java17</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>

--- a/google-http-client-appengine/pom.xml
+++ b/google-http-client-appengine/pom.xml
@@ -17,7 +17,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://cloud.google.com/appengine/docs/standard/java/javadoc/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>

--- a/google-http-client-findbugs/google-http-client-findbugs-test/pom.xml
+++ b/google-http-client-findbugs/google-http-client-findbugs-test/pom.xml
@@ -13,8 +13,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/google-http-client-gson/pom.xml
+++ b/google-http-client-gson/pom.xml
@@ -17,7 +17,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://www.javadoc.io/doc/com.google.code.gson/gson/${project.gson.version}</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>

--- a/google-http-client-jackson/pom.xml
+++ b/google-http-client-jackson/pom.xml
@@ -17,7 +17,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://jar-download.com/artifacts/org.codehaus.jackson/jackson-core-asl/${project.jackson-core-asl.version}/documentation</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>

--- a/google-http-client-jackson2/pom.xml
+++ b/google-http-client-jackson2/pom.xml
@@ -17,7 +17,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>http://fasterxml.github.com/jackson-core/javadoc/${project.jackson-core2.version}/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>

--- a/google-http-client-jdo/pom.xml
+++ b/google-http-client-jdo/pom.xml
@@ -17,7 +17,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/google-http-client-protobuf/pom.xml
+++ b/google-http-client-protobuf/pom.xml
@@ -24,7 +24,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/google-http-client-test/pom.xml
+++ b/google-http-client-test/pom.xml
@@ -17,7 +17,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/google-http-client-xml/pom.xml
+++ b/google-http-client-xml/pom.xml
@@ -17,7 +17,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://google.github.io/guava/releases/${project.guava.version}/api/docs/</link>
             <link>https://commons.apache.org/proper/commons-codec/archives/${project.commons-codec.version}/apidocs/</link>
           </links>

--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
             <phase>site</phase>
             <configuration>
               <links>
-                <link>http://download.oracle.com/javase/6/docs/api/</link>
+                <link>http://download.oracle.com/javase/7/docs/api/</link>
                 <link>http://cloud.google.com/appengine/docs/java/javadoc</link>
                 <link>https://jar-download.com/artifacts/org.codehaus.jackson/jackson-core-asl/${project.jackson-core-asl.version}/documentation</link>
                 <link>http://fasterxml.github.com/jackson-core/javadoc/${project.jackson-core2.version}/</link>

--- a/pom.xml
+++ b/pom.xml
@@ -294,8 +294,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>2.3.2</version>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.7</source>
+            <target>1.7</target>
           </configuration>
         </plugin>
         <plugin>
@@ -505,7 +505,7 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
+            <artifactId>java17</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>


### PR DESCRIPTION
We're dropping Java 6 in the next release, so set the maven-compiler to use source level 1.7 and to compile to 1.7 binary. Also update animal-sniffer-plugin to java17 to allow 1.7 source.
