### PR TITLE
Fix iterable maps JSON serialization

### DIFF
--- a/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonGeneratorTest.java
+++ b/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonGeneratorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.api.client.json.gson;
+
+import com.google.api.client.json.JsonGenerator;
+import com.google.api.client.test.json.AbstractJsonGeneratorTest;
+import java.io.IOException;
+import java.io.Writer;
+
+public class GsonGeneratorTest extends AbstractJsonGeneratorTest {
+
+  private static final GsonFactory FACTORY = new GsonFactory();
+
+  @Override
+  protected JsonGenerator newGenerator(Writer writer) throws IOException {
+    return FACTORY.createJsonGenerator(writer);
+  }
+}

--- a/google-http-client-jackson/src/test/java/com/google/api/client/json/jackson/JacksonGeneratorTest.java
+++ b/google-http-client-jackson/src/test/java/com/google/api/client/json/jackson/JacksonGeneratorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.api.client.json.jackson;
+
+import com.google.api.client.json.JsonGenerator;
+import com.google.api.client.test.json.AbstractJsonGeneratorTest;
+import java.io.IOException;
+import java.io.Writer;
+
+public class JacksonGeneratorTest extends AbstractJsonGeneratorTest {
+
+  private static final JacksonFactory FACTORY = new JacksonFactory();
+
+  @Override
+  protected JsonGenerator newGenerator(Writer writer) throws IOException {
+    return FACTORY.createJsonGenerator(writer);
+  }
+}

--- a/google-http-client-jackson2/src/test/java/com/google/api/client/json/jackson2/JacksonGeneratorTest.java
+++ b/google-http-client-jackson2/src/test/java/com/google/api/client/json/jackson2/JacksonGeneratorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.api.client.json.jackson2;
+
+import com.google.api.client.json.JsonGenerator;
+import com.google.api.client.test.json.AbstractJsonGeneratorTest;
+import java.io.IOException;
+import java.io.Writer;
+
+public class JacksonGeneratorTest extends AbstractJsonGeneratorTest {
+
+  private static final JacksonFactory FACTORY = new JacksonFactory();
+
+  @Override
+  protected JsonGenerator newGenerator(Writer writer) throws IOException {
+    return FACTORY.createJsonGenerator(writer);
+  }
+}

--- a/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonGeneratorTest.java
+++ b/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonGeneratorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.api.client.test.json;
+
+import com.google.api.client.json.JsonGenerator;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import junit.framework.TestCase;
+
+public abstract class AbstractJsonGeneratorTest extends TestCase {
+
+  protected abstract JsonGenerator newGenerator(Writer writer) throws IOException;
+
+  class IterableMap extends HashMap<String, String> implements Iterable<Map.Entry<String, String>> {
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+      return entrySet().iterator();
+    }
+  }
+
+  public void testSerialize_simpleMap() throws Exception {
+    StringWriter writer = new StringWriter();
+    JsonGenerator generator = newGenerator(writer);
+
+    Map m = new HashMap<String, String>();
+    m.put("a", "b");
+    m.put("c", "d");
+
+    generator.serialize(m);
+    generator.close();
+    assertEquals("{\"a\":\"b\",\"c\":\"d\"}", writer.toString());
+  }
+
+  public void testSerialize_iterableMap() throws Exception {
+    StringWriter writer = new StringWriter();
+    JsonGenerator generator = newGenerator(writer);
+
+    Map m = new IterableMap();
+    m.put("a", "b");
+    m.put("c", "d");
+
+    generator.serialize(m);
+    generator.close();
+    assertEquals("{\"a\":\"b\",\"c\":\"d\"}", writer.toString());
+  }
+}

--- a/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonGeneratorTest.java
+++ b/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonGeneratorTest.java
@@ -40,11 +40,10 @@ public abstract class AbstractJsonGeneratorTest extends TestCase {
 
     Map m = new HashMap<String, String>();
     m.put("a", "b");
-    m.put("c", "d");
 
     generator.serialize(m);
     generator.close();
-    assertEquals("{\"a\":\"b\",\"c\":\"d\"}", writer.toString());
+    assertEquals("{\"a\":\"b\"}", writer.toString());
   }
 
   public void testSerialize_iterableMap() throws Exception {
@@ -53,10 +52,9 @@ public abstract class AbstractJsonGeneratorTest extends TestCase {
 
     Map m = new IterableMap();
     m.put("a", "b");
-    m.put("c", "d");
 
     generator.serialize(m);
     generator.close();
-    assertEquals("{\"a\":\"b\",\"c\":\"d\"}", writer.toString());
+    assertEquals("{\"a\":\"b\"}", writer.toString());
   }
 }

--- a/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonGeneratorTest.java
+++ b/google-http-client-test/src/main/java/com/google/api/client/test/json/AbstractJsonGeneratorTest.java
@@ -29,7 +29,7 @@ public abstract class AbstractJsonGeneratorTest extends TestCase {
 
   class IterableMap extends HashMap<String, String> implements Iterable<Map.Entry<String, String>> {
     @Override
-    public Iterator<Entry<String, String>> iterator() {
+    public Iterator<Map.Entry<String, String>> iterator() {
       return entrySet().iterator();
     }
   }

--- a/google-http-client/src/main/java/com/google/api/client/json/JsonGenerator.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/JsonGenerator.java
@@ -141,7 +141,8 @@ public abstract class JsonGenerator implements Closeable, Flushable {
       writeBoolean((Boolean) value);
     } else if (value instanceof DateTime) {
       writeString(((DateTime) value).toStringRfc3339());
-    } else if (value instanceof Iterable<?> || valueClass.isArray()) {
+    } else if ((value instanceof Iterable<?> || valueClass.isArray()) && 
+               !(value instanceof Map<?, ?>) && !(value instanceof GenericData)) {
       writeStartArray();
       for (Object o : Types.iterableOf(value)) {
         serialize(isJsonString, o);


### PR DESCRIPTION
From #404 

If a map is iterable, then the JSON generator treats the map as an array when it should still be treated as a JSON object.