### PR TITLE
Use maven enforcer plugin for maven version requirements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,6 @@
 
   <inceptionYear>2011</inceptionYear>
 
-  <prerequisites>
-    <maven>3.5.4</maven>
-  </prerequisites>
-
   <scm>
     <connection>scm:git:https://github.com/googleapis/google-http-java-client.git</connection>
     <developerConnection>scm:git:git@github.com:googleapis/google-http-java-client.git</developerConnection>
@@ -401,6 +397,25 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M2</version><executions>
+        <execution>
+          <id>enforce-maven</id>
+          <goals>
+            <goal>enforce</goal>
+          </goals>
+          <configuration>
+            <rules>
+              <requireMavenVersion>
+                <version>[3.5.4,4.0.0)</version>
+              </requireMavenVersion>
+            </rules>
+          </configuration>
+        </execution>
+      </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
Fixes warning about trying to set maven version in `<prerequisites>` tag.