### PR TITLE
Update OpenCensus deprecations

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/OpenCensusUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/OpenCensusUtils.java
@@ -22,8 +22,8 @@ import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.contrib.http.util.HttpPropagationUtil;
 import io.opencensus.trace.BlankSpan;
 import io.opencensus.trace.EndSpanOptions;
-import io.opencensus.trace.NetworkEvent;
-import io.opencensus.trace.NetworkEvent.Type;
+import io.opencensus.trace.MessageEvent;
+import io.opencensus.trace.MessageEvent.Type;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
 import io.opencensus.trace.Tracer;
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
  * Utilities for Census monitoring and tracing.
  *
  * @author Hailong Wen
- * @since 1.24
+ * @since 1.28
  */
 public class OpenCensusUtils {
 
@@ -213,12 +213,12 @@ public class OpenCensusUtils {
    * @param size Size of the response.
    */
   public static void recordReceivedMessageEvent(Span span, long size) {
-    recordMessageEvent(span, size, Type.RECV);
+    recordMessageEvent(span, size, Type.RECEIVED);
   }
 
   /**
-   * Records a message event of a certain {@link NetworkEvent.Type}. This method is package
-   * protected since {@link NetworkEvent} might be deprecated in future releases.
+   * Records a message event of a certain {@link MessageEvent.Type}. This method is package
+   * protected since {@link MessageEvent} might be deprecated in future releases.
    *
    * @param span The {@code span} in which the event occurs.
    * @param size Size of the message.
@@ -230,11 +230,11 @@ public class OpenCensusUtils {
     if (size < 0) {
       size = 0;
     }
-    NetworkEvent event = NetworkEvent
+    MessageEvent event = MessageEvent
         .builder(eventType, idGenerator.getAndIncrement())
         .setUncompressedMessageSize(size)
         .build();
-    span.addNetworkEvent(event);
+    span.addMessageEvent(event);
   }
 
   static {

--- a/google-http-client/src/test/java/com/google/api/client/util/OpenCensusUtilsTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/OpenCensusUtilsTest.java
@@ -21,7 +21,7 @@ import io.opencensus.trace.EndSpanOptions;
 import io.opencensus.trace.Annotation;
 import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.Link;
-import io.opencensus.trace.NetworkEvent;
+import io.opencensus.trace.MessageEvent;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Status;
@@ -30,8 +30,6 @@ import io.opencensus.trace.propagation.TextFormat;
 import java.util.List;
 import java.util.Map;
 import junit.framework.TestCase;
-import org.junit.Assert;
-import org.junit.Rule;
 
 /**
  * Tests {@link OpenCensusUtils}.
@@ -87,8 +85,8 @@ public class OpenCensusUtilsTest extends TestCase {
       public void addAnnotation(Annotation annotation) {}
 
       @Override
-      public void addNetworkEvent(NetworkEvent event) {
-        throw new UnsupportedOperationException("Span.addNetworkEvent");
+      public void addMessageEvent(MessageEvent event) {
+        throw new UnsupportedOperationException("Span.addMessageEvent");
       }
 
       @Override
@@ -221,7 +219,7 @@ public class OpenCensusUtilsTest extends TestCase {
 
   public void testRecordMessageEventInNullSpan() {
     try {
-      OpenCensusUtils.recordMessageEvent(null, 0, NetworkEvent.Type.SENT);
+      OpenCensusUtils.recordMessageEvent(null, 0, MessageEvent.Type.SENT);
       fail("expected " + IllegalArgumentException.class);
     } catch (IllegalArgumentException e) {
       assertEquals(e.getMessage(), "span should not be null.");
@@ -230,10 +228,10 @@ public class OpenCensusUtilsTest extends TestCase {
 
   public void testRecordMessageEvent() {
     try {
-      OpenCensusUtils.recordMessageEvent(mockSpan, 0, NetworkEvent.Type.SENT);
+      OpenCensusUtils.recordMessageEvent(mockSpan, 0, MessageEvent.Type.SENT);
       fail("expected " + UnsupportedOperationException.class);
     } catch (UnsupportedOperationException e) {
-      assertEquals(e.getMessage(), "Span.addNetworkEvent");
+      assertEquals(e.getMessage(), "Span.addMessageEvent");
     }
   }
 }


### PR DESCRIPTION
Also fixes the `@since` tag as this is just now being introduced (not in 1.24)
