### PR TITLE
Provide STAGING_REPOSITORY_ID as an environment variable

### DIFF
--- a/.kokoro/release/drop.sh
+++ b/.kokoro/release/drop.sh
@@ -15,11 +15,18 @@
 
 set -eo pipefail
 
-source $(dirname "$0")/common.sh
+# STAGING_REPOSITORY_ID must be set
+if [ -z "${STAGING_REPOSITORY_ID}" ]; then
+  echo "Missing STAGING_REPOSITORY_ID environment variable"
+  exit 1
+fi
 
+source $(dirname "$0")/common.sh
 pushd $(dirname "$0")/../../
 
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-mvn nexus-staging:drop --settings=settings.xml
+mvn nexus-staging:drop -B \
+  --settings=settings.xml \
+  -DstagingRepositoryId=${STAGING_REPOSITORY_ID}

--- a/.kokoro/release/promote.sh
+++ b/.kokoro/release/promote.sh
@@ -15,6 +15,12 @@
 
 set -eo pipefail
 
+# STAGING_REPOSITORY_ID must be set
+if [ -z "${STAGING_REPOSITORY_ID}" ]; then
+  echo "Missing STAGING_REPOSITORY_ID environment variable"
+  exit 1
+fi
+
 source $(dirname "$0")/common.sh
 
 pushd $(dirname "$0")/../../
@@ -22,4 +28,7 @@ pushd $(dirname "$0")/../../
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-mvn nexus-staging:release -DperformRelease=true --settings=settings.xml
+mvn nexus-staging:release -B \
+  -DperformRelease=true \
+  --settings=settings.xml \
+  -DstagingRepositoryId=${STAGING_REPOSITORY_ID}


### PR DESCRIPTION
Allows use to use the drop/promote Kokoro jobs by providing the STAGING_REPOSITORY_ID via environment variable