### PR TITLE
Remove commons-codec dependency

### DIFF
--- a/google-http-client-assembly/pom.xml
+++ b/google-http-client-assembly/pom.xml
@@ -79,7 +79,7 @@
             <configuration>
               <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
               <outputDirectory>${project.build.directory}/libs</outputDirectory>
-              <excludeArtifactIds>android,opengl-api,xmlParserAPIs,commons-codec,json</excludeArtifactIds>
+              <excludeArtifactIds>android,opengl-api,xmlParserAPIs,json</excludeArtifactIds>
             </configuration>
           </execution>
           <execution>
@@ -92,7 +92,7 @@
               <classifier>sources</classifier>
               <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
               <outputDirectory>${project.build.directory}/libs-sources</outputDirectory>
-              <excludeArtifactIds>android,opengl-api,xmlParserAPIs,commons-codec,json</excludeArtifactIds>
+              <excludeArtifactIds>android,opengl-api,xmlParserAPIs,json</excludeArtifactIds>
             </configuration>
           </execution>
         </executions>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -23,7 +23,6 @@
           <links>
             <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://google.github.io/guava/releases/${project.guava.version}/api/docs/</link>
-            <link>https://commons.apache.org/proper/commons-codec/archives/${project.commons-codec.version}/apidocs/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>
@@ -38,68 +37,6 @@
             <goals>
               <goal>jar</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- Use jarjar to include a private copy of Apache Commons Codec library
-           to avoid a runtime dependency conflict with Android which includes
-           an older version of that library, as well as Guava JDK5. -->
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>jarjar-maven-plugin</artifactId>
-        <version>1.9</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>jarjar</goal>
-            </goals>
-            <configuration>
-              <includes>
-                <include>commons-codec:commons-codec</include>
-                <include>com.google.guava:guava</include>
-              </includes>
-              <rules>
-                <rule>
-                  <pattern>org.apache.commons.codec.**</pattern>
-                  <result>com.google.api.client.repackaged.org.apache.commons.codec.@1</result>
-                </rule>
-                <rule>
-                  <pattern>com.google.common.**</pattern>
-                  <result>com.google.api.client.repackaged.com.google.common.@1</result>
-                </rule>
-                <keep>
-                  <pattern>com.google.api.client.**</pattern>
-                </keep>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.8</version>
-        <executions>
-          <!-- Remove extraneous files from the jarjar'ed Apache Commons Codec
-               Library. -->
-          <execution>
-            <id>scrub</id>
-            <phase>package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <jar destfile="target/scrubbed.jar" filesetmanifest="merge">
-                  <zipfileset src="target/google-http-client-${project.version}.jar">
-                    <exclude name="**/org/apache/commons/codec/language/bm/*.txt"/>
-                    <exclude name="META-INF/*.txt"/>
-                    <exclude name="META-INF/maven/**"/>
-                  </zipfileset>
-                </jar>
-                <move file="target/scrubbed.jar" tofile="target/google-http-client-${project.version}.jar"/>
-              </target>
-            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -164,10 +101,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.j2objc</groupId>

--- a/google-http-client/src/main/java/com/google/api/client/util/Base64.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Base64.java
@@ -14,16 +14,11 @@
 
 package com.google.api.client.util;
 
+import com.google.common.io.BaseEncoding;
+import com.google.common.io.BaseEncoding.DecodingException;
+
 /**
- * Proxy for version 1.6 (or newer) of the Apache Commons Codec
- * {@link org.apache.commons.codec.binary.Base64} implementation.
- *
- * <p>
- * This is needed in order to support platforms like Android which already include an older version
- * of the Apache Commons Codec (Android includes version 1.3). To avoid a dependency library
- * conflict, this library includes a reduced private copy of version 1.6 (or newer) of the Apache
- * Commons Codec (using a tool like jarjar).
- * </p>
+ * Proxy for handling Base64 encoding/decoding.
  *
  * @since 1.8
  * @author Yaniv Inbar
@@ -36,10 +31,9 @@ public class Base64 {
    * @param binaryData binary data to encode or {@code null} for {@code null} result
    * @return byte[] containing Base64 characters in their UTF-8 representation or {@code null} for
    *         {@code null} input
-   * @see org.apache.commons.codec.binary.Base64#encodeBase64(byte[])
    */
   public static byte[] encodeBase64(byte[] binaryData) {
-    return org.apache.commons.codec.binary.Base64.encodeBase64(binaryData);
+    return StringUtils.getBytesUtf8(encodeBase64String(binaryData));
   }
 
   /**
@@ -47,10 +41,9 @@ public class Base64 {
    *
    * @param binaryData binary data to encode or {@code null} for {@code null} result
    * @return String containing Base64 characters or {@code null} for {@code null} input
-   * @see org.apache.commons.codec.binary.Base64#encodeBase64String(byte[])
    */
   public static String encodeBase64String(byte[] binaryData) {
-    return org.apache.commons.codec.binary.Base64.encodeBase64String(binaryData);
+    return BaseEncoding.base64().encode(binaryData);
   }
 
 
@@ -61,10 +54,9 @@ public class Base64 {
    * @param binaryData binary data to encode or {@code null} for {@code null} result
    * @return byte[] containing Base64 characters in their UTF-8 representation or {@code null} for
    *         {@code null} input
-   * @see org.apache.commons.codec.binary.Base64#encodeBase64URLSafe(byte[])
    */
   public static byte[] encodeBase64URLSafe(byte[] binaryData) {
-    return org.apache.commons.codec.binary.Base64.encodeBase64URLSafe(binaryData);
+    return StringUtils.getBytesUtf8(encodeBase64URLSafeString(binaryData));
   }
 
   /**
@@ -73,32 +65,38 @@ public class Base64 {
    *
    * @param binaryData binary data to encode or {@code null} for {@code null} result
    * @return String containing Base64 characters or {@code null} for {@code null} input
-   * @see org.apache.commons.codec.binary.Base64#encodeBase64URLSafeString(byte[])
    */
   public static String encodeBase64URLSafeString(byte[] binaryData) {
-    return org.apache.commons.codec.binary.Base64.encodeBase64URLSafeString(binaryData);
+    return BaseEncoding.base64().omitPadding().encode(binaryData);
   }
 
   /**
-   * Decodes Base64 data into octets.
+   * Decodes Base64 data into octets. Note that this method handles both URL-safe and
+   * non-URL-safe base 64 encoded inputs.
    *
    * @param base64Data Byte array containing Base64 data or {@code null} for {@code null} result
    * @return Array containing decoded data or {@code null} for {@code null} input
-   * @see org.apache.commons.codec.binary.Base64#decodeBase64(byte[])
    */
   public static byte[] decodeBase64(byte[] base64Data) {
-    return org.apache.commons.codec.binary.Base64.decodeBase64(base64Data);
+    return decodeBase64(StringUtils.newStringUtf8(base64Data));
   }
 
   /**
-   * Decodes a Base64 String into octets.
+   * Decodes a Base64 String into octets. Note that this method handles both URL-safe and
+   * non-URL-safe base 64 encoded strings.
    *
    * @param base64String String containing Base64 data or {@code null} for {@code null} result
    * @return Array containing decoded data or {@code null} for {@code null} input
-   * @see org.apache.commons.codec.binary.Base64#decodeBase64(String)
    */
   public static byte[] decodeBase64(String base64String) {
-    return org.apache.commons.codec.binary.Base64.decodeBase64(base64String);
+    try {
+      return BaseEncoding.base64().decode(base64String);
+    } catch (IllegalArgumentException e) {
+      if (e.getCause() instanceof DecodingException) {
+        return BaseEncoding.base64Url().decode(base64String);
+      }
+      throw e;
+    }
   }
 
   private Base64() {

--- a/google-http-client/src/main/java/com/google/api/client/util/Base64.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Base64.java
@@ -67,7 +67,7 @@ public class Base64 {
    * @return String containing Base64 characters or {@code null} for {@code null} input
    */
   public static String encodeBase64URLSafeString(byte[] binaryData) {
-    return BaseEncoding.base64().omitPadding().encode(binaryData);
+    return BaseEncoding.base64Url().omitPadding().encode(binaryData);
   }
 
   /**

--- a/google-http-client/src/main/java/com/google/api/client/util/StringUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/StringUtils.java
@@ -15,18 +15,11 @@
 package com.google.api.client.util;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 
 /**
  * Utilities for strings.
- *
- * <p>
- * Some of these methods are a proxy for version 1.6 (or newer) of the Apache Commons Codec
- * {@link StringUtils} implementation. This is needed in order to support platforms like Android
- * which already include an older version of the Apache Commons Codec (Android includes version
- * 1.3). To avoid a dependency library conflict, this library includes a reduced private copy of
- * version 1.6 (or newer) of the Apache Commons Codec (using a tool like jarjar).
- * </p>
  *
  * @since 1.8
  * @author Yaniv Inbar
@@ -48,13 +41,15 @@ public class StringUtils {
    * @return encoded bytes, or <code>null</code> if the input string was <code>null</code>
    * @throws IllegalStateException Thrown when the charset is missing, which should be never
    *         according the the Java specification.
-   * @see <a href="http://download.oracle.com/javase/1.5.0/docs/api/java/nio/charset/Charset.html"
+   * @see <a href="http://download.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html"
    *      >Standard charsets</a>
-   * @see org.apache.commons.codec.binary.StringUtils#getBytesUtf8(String)
    * @since 1.8
    */
   public static byte[] getBytesUtf8(String string) {
-    return org.apache.commons.codec.binary.StringUtils.getBytesUtf8(string);
+    if (string == null) {
+      return null;
+    }
+    return string.getBytes(StandardCharsets.UTF_8);
   }
 
   /**
@@ -66,11 +61,13 @@ public class StringUtils {
    *         charset, or <code>null</code> if the input byte array was <code>null</code>.
    * @throws IllegalStateException Thrown when a {@link UnsupportedEncodingException} is caught,
    *         which should never happen since the charset is required.
-   * @see org.apache.commons.codec.binary.StringUtils#newStringUtf8(byte[])
    * @since 1.8
    */
   public static String newStringUtf8(byte[] bytes) {
-    return org.apache.commons.codec.binary.StringUtils.newStringUtf8(bytes);
+    if (bytes == null) {
+      return null;
+    }
+    return new String(bytes, StandardCharsets.UTF_8);
   }
 
   private StringUtils() {

--- a/google-http-client/src/test/java/com/google/api/client/util/StringUtilsTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/StringUtilsTest.java
@@ -40,7 +40,15 @@ public class StringUtilsTest extends TestCase {
     Assert.assertArrayEquals(SAMPLE_UTF8, StringUtils.getBytesUtf8(SAMPLE));
   }
 
+  public void testToBytesUtf8Null() {
+    assertNull(StringUtils.getBytesUtf8(null));
+  }
+
   public void testFromBytesUtf8() {
     assertEquals(SAMPLE, StringUtils.newStringUtf8(SAMPLE_UTF8));
+  }
+
+  public void testFromBytesUtf8Null() {
+    assertNull(StringUtils.newStringUtf8(null));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -151,11 +151,6 @@
         <version>${project.httpclient.version}</version>
       </dependency>
       <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${project.commons-codec.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${project.guava.version}</version>
@@ -436,7 +431,6 @@
                 <link>http://fasterxml.github.com/jackson-core/javadoc/${project.jackson-core2.version}/</link>
                 <link>https://www.javadoc.io/doc/com.google.code.gson/gson/${project.gson.version}</link>
                 <link>https://google.github.io/guava/releases/${project.guava.version}/api/docs/</link>
-                <link>https://commons.apache.org/proper/commons-codec/archives/${project.commons-codec.version}/apidocs/</link>
               </links>
               <doctitle>Google HTTP Client Library for Java ${project.version}</doctitle>
               <excludePackageNames>com.google.api.client.findbugs:com.google.api.client.test.:com.google.api.services</excludePackageNames>
@@ -575,7 +569,6 @@
     <project.guava.version>26.0-android</project.guava.version>
     <project.xpp3.version>1.1.4c</project.xpp3.version>
     <project.commons-logging.version>1.1.1</project.commons-logging.version>
-    <project.commons-codec.version>1.11</project.commons-codec.version>
     <project.httpclient.version>4.5.5</project.httpclient.version>
     <project.jdo2-api.version>2.3-eb</project.jdo2-api.version>
     <project.datanucleus-core.version>3.2.2</project.datanucleus-core.version>


### PR DESCRIPTION
Fixes #457 

Use guava Base64 handling until we drop Java 7 support and can use the built-in classes.
Use Java 7 charset handling for StringUtils.

By removing commons-codec, we should no longer need to jarjar a shaded version of commons-codec (and guava). We can also remove the antrun plugin which scrubbed the shaded commons-codec. This will also unblock the windows tests in #562 (file permissions errors during antrun plugin) Edit: it unblocked it, but there are more failures.