### PR TITLE
Move OpenCensusUtils to com.google.api.client.http

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -18,7 +18,6 @@ import com.google.api.client.util.Beta;
 import com.google.api.client.util.IOUtils;
 import com.google.api.client.util.LoggingStreamingContent;
 import com.google.api.client.util.ObjectParser;
-import com.google.api.client.util.OpenCensusUtils;
 import com.google.api.client.util.Preconditions;
 import com.google.api.client.util.Sleeper;
 import com.google.api.client.util.StreamingContent;

--- a/google-http-client/src/main/java/com/google/api/client/http/OpenCensusUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/OpenCensusUtils.java
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
  * @author Hailong Wen
  * @since 1.28
  */
-public class OpenCensusUtils {
+class OpenCensusUtils {
 
   private static final Logger logger = Logger.getLogger(OpenCensusUtils.class.getName());
 

--- a/google-http-client/src/main/java/com/google/api/client/http/OpenCensusUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/OpenCensusUtils.java
@@ -12,11 +12,9 @@
  * the License.
  */
 
-package com.google.api.client.util;
+package com.google.api.client.http;
 
-import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.util.Preconditions;
 import com.google.common.annotations.VisibleForTesting;
 
 import io.opencensus.contrib.http.util.HttpPropagationUtil;

--- a/google-http-client/src/test/java/com/google/api/client/http/OpenCensusUtilsTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/OpenCensusUtilsTest.java
@@ -12,7 +12,7 @@
  * the License.
  */
 
-package com.google.api.client.util;
+package com.google.api.client.http;
 
 import com.google.api.client.http.HttpHeaders;
 


### PR DESCRIPTION
Avoid circular dependency between packages.
Also makes the class default visibility as it's an internal class. This should be fine because it hasn't been released yet.