### PR TITLE
OpenCensusUtils does need to be public

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/OpenCensusUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/OpenCensusUtils.java
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
  * @author Hailong Wen
  * @since 1.28
  */
-class OpenCensusUtils {
+public class OpenCensusUtils {
 
   private static final Logger logger = Logger.getLogger(OpenCensusUtils.class.getName());
 


### PR DESCRIPTION
Users need the ability to configure the propagation format and other configs.