### PR TITLE
Fix handling interrupted uploads

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpRequest.java
@@ -117,6 +117,12 @@ final class NetHttpRequest extends LowLevelHttpRequest {
           writeContentToOutputStream(outputWriter, out);
 
           threw = false;
+        } catch (IOException e) {
+          // If we've gotten a response back, continue on and try to parse the response. Otherwise,
+          // re-throw the IOException
+          if (!hasReponse(connection)) {
+            throw e;
+          }
         } finally {
           try {
             out.close();
@@ -147,6 +153,15 @@ final class NetHttpRequest extends LowLevelHttpRequest {
       if (!successfulConnection) {
         connection.disconnect();
       }
+    }
+  }
+
+  private boolean hasReponse(HttpURLConnection connection) {
+    try {
+      return connection.getResponseCode() > 0;
+    } catch (IOException e) {
+      // There's some exception trying to parse the response
+      return false;
     }
   }
 

--- a/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpRequestTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpRequestTest.java
@@ -2,6 +2,7 @@ package com.google.api.client.http.javanet;
 
 import com.google.api.client.http.HttpContent;
 import com.google.api.client.http.InputStreamContent;
+import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.http.javanet.NetHttpRequest.OutputWriter;
 import com.google.api.client.testing.http.HttpTesting;
 import com.google.api.client.testing.http.javanet.MockHttpURLConnection;
@@ -80,6 +81,57 @@ public class NetHttpRequestTest {
     request.setStreamingContent(content);
     request.setWriteTimeout(timeout);
     request.execute(new SleepingOutputWriter(5000L));
+  }
+
+  @Test
+  public void testInterruptedWriteWithResponse() throws Exception {
+    MockHttpURLConnection connection = new MockHttpURLConnection(new URL(HttpTesting.SIMPLE_URL)) {
+      @Override
+      public OutputStream getOutputStream() throws IOException {
+        return new OutputStream() {
+          @Override
+          public void write(int b) throws IOException {
+            throw new IOException("Error writing request body to server");
+          }
+        };
+      }
+    };
+    connection.setResponseCode(401);
+    connection.setRequestMethod("POST");
+    NetHttpRequest request = new NetHttpRequest(connection);
+    InputStream is = NetHttpRequestTest.class.getClassLoader().getResourceAsStream("file.txt");
+    HttpContent content = new InputStreamContent("text/plain", is);
+    request.setStreamingContent(content);
+
+    LowLevelHttpResponse response = request.execute();
+    assertEquals(401, response.getStatusCode());
+  }
+
+  @Test
+  public void testInterruptedWriteWithoutResponse() throws Exception {
+    MockHttpURLConnection connection = new MockHttpURLConnection(new URL(HttpTesting.SIMPLE_URL)) {
+      @Override
+      public OutputStream getOutputStream() throws IOException {
+        return new OutputStream() {
+          @Override
+          public void write(int b) throws IOException {
+            throw new IOException("Error writing request body to server");
+          }
+        };
+      }
+    };
+    connection.setRequestMethod("POST");
+    NetHttpRequest request = new NetHttpRequest(connection);
+    InputStream is = NetHttpRequestTest.class.getClassLoader().getResourceAsStream("file.txt");
+    HttpContent content = new InputStreamContent("text/plain", is);
+    request.setStreamingContent(content);
+
+    try {
+      request.execute();
+      fail("Expected to throw an IOException");
+    } catch (IOException e) {
+      assertEquals("Error writing request body to server", e.getMessage());
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #530 
cc @dzelemba

It's possible that a server handling a POST/PUT with content will interrupt the write and return a response. If this is the case, we should be able to read the response rather than throwing an IOException.