### PR TITLE
depend directly on Apache httpclient

### DIFF
--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -68,11 +68,11 @@
     </plugins>
   </build>
   <dependencies>
-<dependency>
-  <groupId>org.apache.httpcomponents</groupId>
-  <artifactId>httpclient</artifactId>
-  <version>4.3.6</version>
-</dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.3.6</version>
+    </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -12,7 +12,7 @@
   <name>Google HTTP Client Library for Java</name>
   <description>
     Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,
-    including Java 6 (or higher) desktop (SE) and web (EE), Android, and Google App Engine.
+    including Java 7 (or higher) desktop (SE) and web (EE), Android, and Google App Engine.
   </description>
 
   <build>
@@ -68,12 +68,11 @@
     </plugins>
   </build>
   <dependencies>
-    <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <version>1.5_r4</version>
-      <scope>provided</scope>
-    </dependency>
+<dependency>
+  <groupId>org.apache.httpcomponents</groupId>
+  <artifactId>httpclient</artifactId>
+  <version>4.3.6</version>
+</dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -71,7 +71,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.3.6</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
depend directly on Apache httpclient instead of pulling it in transitively from weird android dependency.

- [X] Tests pass
- [X] Appropriate docs were updated (if necessary)

Not sure why tests didn't run, but there's a local failure I'm investigating.

OK.  tests passed locally. First failure was probably a DNS glitch caused by putting laptop to sleep in the middle. 


@sduskis I'm still concerned that the kokoro jobs didn't fire here.