### PR TITLE
Release google-http-java-client v1.29.0

### DIFF
--- a/google-http-client-android-test/pom.xml
+++ b/google-http-client-android-test/pom.xml
@@ -4,7 +4,7 @@
   <groupId>google-http-client</groupId>
   <artifactId>google-http-client-android-test</artifactId>
   <name>Test project for google-http-client-android.</name>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-android-test:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-android-test:current} -->
   <packaging>apk</packaging>
 
   <build>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-android</artifactId>
-      <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+      <version>1.29.0</version><!-- {x-version-update:google-http-client-android:current} -->
       <exclusions>
         <exclusion>
           <artifactId>android</artifactId>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-test</artifactId>
-      <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+      <version>1.29.0</version><!-- {x-version-update:google-http-client-test:current} -->
       <exclusions>
         <exclusion>
           <artifactId>junit</artifactId>

--- a/google-http-client-android/pom.xml
+++ b/google-http-client-android/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-android</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-android:current} -->
   <name>Android Platform Extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-apache-legacy/pom.xml
+++ b/google-http-client-apache-legacy/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-apache</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-apache-legacy:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-apache-legacy:current} -->
   <name>Legacy Apache HTTP transport for the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-apache/pom.xml
+++ b/google-http-client-apache/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-apache</artifactId>
-  <version>2.0.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-apache:current} -->
+  <version>2.1.0</version><!-- {x-version-update:google-http-client-apache:current} -->
   <name>Apache HTTP transport for the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-appengine/pom.xml
+++ b/google-http-client-appengine/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-appengine</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-appengine:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-appengine:current} -->
   <name>Google App Engine extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-assembly/pom.xml
+++ b/google-http-client-assembly/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-assembly</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-assembly:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-assembly:current} -->
   <packaging>pom</packaging>
   <name>Assembly for the Google HTTP Client Library for Java</name>
 

--- a/google-http-client-bom/README.md
+++ b/google-http-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-bom</artifactId>
-      <version>1.28.0</version>
+      <version>1.29.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-http-client-bom/pom.xml
+++ b/google-http-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-bom</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-bom:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-bom:current} -->
   <packaging>pom</packaging>
 
   <name>Google HTTP Client Library for Java BOM</name>
@@ -63,67 +63,67 @@
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-android</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client-android:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-apache</artifactId>
-        <version>2.0.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-apache:current} -->
+        <version>2.1.0</version><!-- {x-version-update:google-http-client-apache:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-appengine</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-appengine:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client-appengine:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-assembly</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-assembly:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client-assembly:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-findbugs</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-findbugs:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client-findbugs:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-gson</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-gson:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client-gson:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-jackson</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client-jackson:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-jackson2</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson2:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client-jackson2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-jdo</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jdo:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client-jdo:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-protobuf</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-protobuf:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client-protobuf:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-test</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client-test:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-xml</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-xml:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-http-client-xml:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-http-client-findbugs/pom.xml
+++ b/google-http-client-findbugs/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-findbugs</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-findbugs:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-findbugs:current} -->
   <name>Google APIs Client Library Findbugs custom plugin.</name>
 
   <build>

--- a/google-http-client-gson/pom.xml
+++ b/google-http-client-gson/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-gson</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-gson:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-gson:current} -->
   <name>GSON extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-jackson/pom.xml
+++ b/google-http-client-jackson/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jackson</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-jackson:current} -->
   <name>Jackson extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-jackson2/pom.xml
+++ b/google-http-client-jackson2/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jackson2</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson2:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-jackson2:current} -->
   <name>Jackson 2 extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-protobuf/pom.xml
+++ b/google-http-client-protobuf/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-protobuf</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-protobuf:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-protobuf:current} -->
   <name>Protocol Buffer extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-test/pom.xml
+++ b/google-http-client-test/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-test</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-test:current} -->
   <name>Shared classes used for testing of artifacts in the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-xml/pom.xml
+++ b/google-http-client-xml/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-xml</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-xml:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-xml:current} -->
   <name>XML extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client:current} -->
   <name>Google HTTP Client Library for Java</name>
   <description>
     Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-parent</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google HTTP Client Library for Java</name>
 
@@ -543,8 +543,8 @@
       - google-api-java-client/google-api-client-assembly/android-properties (make the filenames match the version here)
       - Internally, update the default features.json file
     -->
-    <project.http-client.version>1.28.1-SNAPSHOT</project.http-client.version><!-- {x-version-update:google-http-client-parent:current} -->
-    <project.http-client-apache.version>2.0.1-SNAPSHOT</project.http-client-apache.version><!-- {x-version-update:google-http-client-apache:current} -->
+    <project.http-client.version>1.29.0</project.http-client.version><!-- {x-version-update:google-http-client-parent:current} -->
+    <project.http-client-apache.version>2.1.0</project.http-client-apache.version><!-- {x-version-update:google-http-client-apache:current} -->
     <project.appengine.version>1.9.71</project.appengine.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.jsr305.version>3.0.2</project.jsr305.version>

--- a/samples/dailymotion-simple-cmdline-sample/pom.xml
+++ b/samples/dailymotion-simple-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>dailymotion-simple-cmdline-sample</artifactId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,20 +1,20 @@
 # Format:
 # module:released-version:current-version
 
-google-http-client:1.28.0:1.28.1-SNAPSHOT
-google-http-client-bom:1.28.0:1.28.1-SNAPSHOT
-google-http-client-parent:1.28.0:1.28.1-SNAPSHOT
-google-http-client-android:1.28.0:1.28.1-SNAPSHOT
-google-http-client-android-test:1.28.0:1.28.1-SNAPSHOT
-google-http-client-apache:2.0.0:2.0.1-SNAPSHOT
-google-http-client-apache-legacy:1.28.0:1.28.1-SNAPSHOT
-google-http-client-appengine:1.28.0:1.28.1-SNAPSHOT
-google-http-client-assembly:1.28.0:1.28.1-SNAPSHOT
-google-http-client-findbugs:1.28.0:1.28.1-SNAPSHOT
-google-http-client-gson:1.28.0:1.28.1-SNAPSHOT
-google-http-client-jackson:1.28.0:1.28.1-SNAPSHOT
-google-http-client-jackson2:1.28.0:1.28.1-SNAPSHOT
-google-http-client-jdo:1.28.0:1.28.1-SNAPSHOT
-google-http-client-protobuf:1.28.0:1.28.1-SNAPSHOT
-google-http-client-test:1.28.0:1.28.1-SNAPSHOT
-google-http-client-xml:1.28.0:1.28.1-SNAPSHOT
+google-http-client:1.29.0:1.29.0
+google-http-client-bom:1.29.0:1.29.0
+google-http-client-parent:1.29.0:1.29.0
+google-http-client-android:1.29.0:1.29.0
+google-http-client-android-test:1.29.0:1.29.0
+google-http-client-apache:2.1.0:2.1.0
+google-http-client-apache-legacy:1.29.0:1.29.0
+google-http-client-appengine:1.29.0:1.29.0
+google-http-client-assembly:1.29.0:1.29.0
+google-http-client-findbugs:1.29.0:1.29.0
+google-http-client-gson:1.29.0:1.29.0
+google-http-client-jackson:1.29.0:1.29.0
+google-http-client-jackson2:1.29.0:1.29.0
+google-http-client-jdo:1.29.0:1.29.0
+google-http-client-protobuf:1.29.0:1.29.0
+google-http-client-test:1.29.0:1.29.0
+google-http-client-xml:1.29.0:1.29.0


### PR DESCRIPTION
This pull request was generated using releasetool.

02-25-2019 10:57 PST

### Implementation Changes
- Implement equals and Hashcode on GenericData ([#589](https://github.com/googleapis/google-http-java-client/pull/589))
- 372: Changed SingleThreadExecutor to FixedThreadPool(1). ([#588](https://github.com/googleapis/google-http-java-client/pull/588))
- Add option to return raw stream from response ([#579](https://github.com/googleapis/google-http-java-client/pull/579))
- Fix handling interrupted uploads ([#572](https://github.com/googleapis/google-http-java-client/pull/572))

### Dependencies
- depend directly on Apache httpclient ([#591](https://github.com/googleapis/google-http-java-client/pull/591))
- upgrade dependencies ([#596](https://github.com/googleapis/google-http-java-client/pull/596))
- more fixes for Java 7 minimum version ([#592](https://github.com/googleapis/google-http-java-client/pull/592))
- remove duplicate version definition ([#594](https://github.com/googleapis/google-http-java-client/pull/594))
- Remove old JDO artifact ([#584](https://github.com/googleapis/google-http-java-client/pull/584))
- remove datanucleus ([#480](https://github.com/googleapis/google-http-java-client/pull/480))
- Cleanup assembly process. ([#565](https://github.com/googleapis/google-http-java-client/pull/565))
- upgrade surefire plugin to fix SUREFIRE-1588 ([#580](https://github.com/googleapis/google-http-java-client/pull/580))

### Documentation
- update instructions ([#598](https://github.com/googleapis/google-http-java-client/pull/598))
- fix comment ([#590](https://github.com/googleapis/google-http-java-client/pull/590))
- Update README.md with Java 7 support ([#577](https://github.com/googleapis/google-http-java-client/pull/577))

### Internal / Testing Changes
- Added unit tests for null enum and unknown enum. ([#602](https://github.com/googleapis/google-http-java-client/pull/602))
- remove Java 5 reference ([#600](https://github.com/googleapis/google-http-java-client/pull/600))
- ignore Mac Finder metadata ([#587](https://github.com/googleapis/google-http-java-client/pull/587))