### PR TITLE
Update dependency io.opencensus:opencensus-api to v0.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -552,7 +552,7 @@
     <project.xpp3.version>1.1.4c</project.xpp3.version>
     <project.commons-logging.version>1.2</project.commons-logging.version>
     <project.httpclient.version>4.5.8</project.httpclient.version>
-    <project.opencensus.version>0.19.2</project.opencensus.version>
+    <project.opencensus.version>0.21.0</project.opencensus.version>
     <project.root-directory>..</project.root-directory>
   </properties>
 


### PR DESCRIPTION
We want to keep the opencensus version at the same place grpc is currently at.