### PR TITLE
Configure Kokoro CI for Windows

### DIFF
--- a/.kokoro/build.bat
+++ b/.kokoro/build.bat
@@ -1,0 +1,3 @@
+:: See documentation in type-shell-output.bat
+￼
+"C:\Program Files\Git\bin\bash.exe" github/google-http-java-client/.kokoro/build.sh

--- a/.kokoro/continuous/java8-win.cfg
+++ b/.kokoro/continuous/java8-win.cfg
@@ -1,0 +1,3 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "google-http-java-client/.kokoro/build.bat"

--- a/.kokoro/presubmit/java8-win.cfg
+++ b/.kokoro/presubmit/java8-win.cfg
@@ -1,0 +1,3 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "google-http-java-client/.kokoro/build.bat"

--- a/google-http-client/src/test/java/com/google/api/client/util/IOUtilsTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/IOUtilsTest.java
@@ -16,6 +16,7 @@ package com.google.api.client.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import junit.framework.TestCase;
 
 /**
@@ -42,24 +43,14 @@ public class IOUtilsTest extends TestCase {
     assertFalse(IOUtils.isSymbolicLink(file));
   }
 
-  public void testIsSymbolicLink_true() throws IOException, InterruptedException {
+  public void testIsSymbolicLink_true() throws IOException {
     File file = File.createTempFile("tmp", null);
     file.deleteOnExit();
     File file2 = new File(file.getCanonicalPath() + "2");
     file2.deleteOnExit();
-    try {
-      Process process =
-          Runtime.getRuntime()
-              .exec(new String[] {"ln", "-s", file.getCanonicalPath(), file2.getCanonicalPath()});
-      process.waitFor();
-      process.destroy();
-    } catch (IOException e) {
-      // ignore because ln command may not be defined
-      return;
-    }
-    // multiple versions of jdk6 cannot detect the symbolic link. Consider support best-effort on
-    // jdk6
-    boolean jdk6 = System.getProperty("java.version").startsWith("1.6.0_");
-    assertTrue(IOUtils.isSymbolicLink(file2) || jdk6);
+    Files.createSymbolicLink(file2.toPath(), file.toPath());
+
+    assertTrue(IOUtils.isSymbolicLink(file2));
   }
 }
+

--- a/pom.xml
+++ b/pom.xml
@@ -559,6 +559,26 @@
 
   <profiles>
     <profile>
+      <id>Windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>release-sign-artifacts</id>
       <activation>
         <property>

--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
           <configuration>
             <rules>
               <requireMavenVersion>
-                <version>[3.5.4,4.0.0)</version>
+                <version>[3.5.2,4.0.0)</version>
               </requireMavenVersion>
             </rules>
           </configuration>


### PR DESCRIPTION
* skip maven-checkstyle-plugin as our exclusion list uses unix-style paths
* relax the required maven version to 3.5.2 as that's what our test runner currently has installed
* use NIO to symlink the file in the IOUtilsTest rather than shelling out to run `ln`

