### PR TITLE
Fix ApacheHttpTransport configuration

### DIFF
--- a/google-http-client-apache-v2/src/main/java/com/google/api/client/http/apache/v2/ApacheHttpRequest.java
+++ b/google-http-client-apache-v2/src/main/java/com/google/api/client/http/apache/v2/ApacheHttpRequest.java
@@ -40,7 +40,7 @@ final class ApacheHttpRequest extends LowLevelHttpRequest {
     // disable redirects as google-http-client handles redirects
     this.requestConfig = RequestConfig.custom()
         .setRedirectsEnabled(false)
-        // TODO: configure in HttpClientBuilder when available
+        // TODO(chingor): configure in HttpClientBuilder when available
         .setStaleConnectionCheckEnabled(false);
   }
 

--- a/google-http-client-apache-v2/src/main/java/com/google/api/client/http/apache/v2/ApacheHttpRequest.java
+++ b/google-http-client-apache-v2/src/main/java/com/google/api/client/http/apache/v2/ApacheHttpRequest.java
@@ -33,11 +33,15 @@ final class ApacheHttpRequest extends LowLevelHttpRequest {
 
   private RequestConfig.Builder requestConfig;
 
+  @SuppressWarnings("deprecation")
   ApacheHttpRequest(HttpClient httpClient, HttpRequestBase request) {
     this.httpClient = httpClient;
     this.request = request;
     // disable redirects as google-http-client handles redirects
-    this.requestConfig = RequestConfig.custom().setRedirectsEnabled(false);
+    this.requestConfig = RequestConfig.custom()
+        .setRedirectsEnabled(false)
+        // TODO: configure in HttpClientBuilder when available
+        .setStaleConnectionCheckEnabled(false);
   }
 
   @Override

--- a/google-http-client-apache-v2/src/main/java/com/google/api/client/http/apache/v2/ApacheHttpTransport.java
+++ b/google-http-client-apache-v2/src/main/java/com/google/api/client/http/apache/v2/ApacheHttpTransport.java
@@ -155,19 +155,14 @@ public final class ApacheHttpTransport extends HttpTransport {
                     .setSndBufSize(8192)
                     .build();
 
-    PoolingHttpClientConnectionManager connectionManager =
-            new PoolingHttpClientConnectionManager(-1, TimeUnit.MILLISECONDS);
-    // Disable the stale connection check (previously configured in the HttpConnectionParams
-    connectionManager.setValidateAfterInactivity(-1);
-
     return HttpClientBuilder.create()
             .useSystemProperties()
             .setSSLSocketFactory(SSLConnectionSocketFactory.getSocketFactory())
             .setDefaultSocketConfig(socketConfig)
             .setMaxConnTotal(200)
             .setMaxConnPerRoute(20)
+            .setConnectionTimeToLive(-1, TimeUnit.MILLISECONDS)
             .setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()))
-            .setConnectionManager(connectionManager)
             .disableRedirectHandling()
             .disableAutomaticRetries();
   }


### PR DESCRIPTION
Fixes #715

Switch back to deprecated `setStaleConnectionCheck`. `HttpClientBuilder` does not expose a way to configure the connection manager's `validateAfterInactivity` configuration. We can either reimplement the entirety of the builder's logic or switch back to a deprecated method.