### PR TITLE
Add GitHub repo, issue tracker metadata for javadoc site

### DIFF
--- a/.kokoro/release/publish_javadoc.sh
+++ b/.kokoro/release/publish_javadoc.sh
@@ -45,7 +45,9 @@ pushd target/site/apidocs
 python3 -m docuploader create-metadata \
   --name ${NAME} \
   --version ${VERSION} \
-  --language java
+  --language java \
+  --github-repository https://github.com/googleapis/google-http-java-client \
+  --issue-tracker https://github.com/googleapis/google-http-java-client/issues \
 
 # upload docs
 python3 -m docuploader upload . \


### PR DESCRIPTION
This will add links to the version selector overlay with links to this repo and to file issues.