### PR TITLE
make HttpResponse implement Closeable

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -20,6 +20,7 @@ import com.google.api.client.util.LoggingInputStream;
 import com.google.api.client.util.Preconditions;
 import com.google.api.client.util.StringUtils;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,13 +46,19 @@ import java.util.zip.GZIPInputStream;
  * response.disconnect();
  * }
  * </pre>
+ * or
+ * <pre>
+ * try (HttpResponse response = request.execute()) {
+ * // process the HTTP response object
+ * }
+ * </pre>
  *
  * <p>Implementation is not thread-safe.
  *
  * @since 1.0
  * @author Yaniv Inbar
  */
-public final class HttpResponse {
+public final class HttpResponse implements Closeable {
 
   /** HTTP response content or {@code null} before {@link #getContent()}. */
   private InputStream content;
@@ -398,9 +405,19 @@ public final class HttpResponse {
    * Close the HTTP response content using {@link #ignore}, and disconnect using {@link
    * LowLevelHttpResponse#disconnect()}.
    *
+   * @see #close()
    * @since 1.4
    */
   public void disconnect() throws IOException {
+    close();
+  }
+
+  /**
+   * Close the HTTP response content using {@link #ignore}, and disconnect using {@link
+   * LowLevelHttpResponse#disconnect()}.
+   */
+  @Override
+  public void close() throws IOException {
     ignore();
     response.disconnect();
   }


### PR DESCRIPTION
Implements #740.

- [x] Tests pass
- [ ] Appropriate docs were updated (if necessary)

---

This PR makes `HttpResponse` implement the `Closeable` interface. I've outlined the benefits that this could give in #740. Hopefully it'll mean
- Can use try-with-resources. :+1: :+1: :+1: 
- More familiar to developers by implementing the standard interface and using standard method names.
- IDEs and static analysis tools may pick up resource leaks automatically without any extra configuration.

However, this does have slightly bigger implications than I originally thought. Consider some code like
```java
Foo foo = request.execute().parseAs(Foo.class);
```
This is a perfectly fine way to use the library, however from a certain perspective it would become invalid if `HttpResponse` were to become closeable because it's "leaking" a closeable object. We know it would still be safe in that it wouldn't leak any resources but it would not be correct from the point of view of the `Closeable` interface because the `close` method is never called.

The danger here is really only that static analyzers might complain, but even that is not too bad as they can normally be silenced or configured to ignore this case. We also don't want to lead people to habitually ignore the `close` method, but that is more a discussion for if `disconnect` is removed or if more implementation is added to `close`.

Note that to be more correct the code could be changed to be like
```java
Foo foo;
try (HttpResponse response = request.execute()) {
    foo = response.parseAs(Foo.class);
}
```
and it would have the same behaviour but is a little bit more verbose.

The other viewpoint is to ignore the above and consider that making `HttpResponse` closeable gives you strictly more options. The above code calling `parseAs` immediately is still correct, however you now also have the option to use try-with-resources to get extra safety when doing something more complicated.

