### PR TITLE
Add support for nanosecond precision when parsing rfc3339 strings

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/DateTime.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/DateTime.java
@@ -263,10 +263,7 @@ public final class DateTime implements Serializable {
    * NumberFormatException}. Also, in accordance with the RFC3339 standard, any number of
    * milliseconds digits is now allowed.
    *
-   * <p>Any time information beyond millisecond precision will be truncated. Prior to version 1.30.2
-   * this method did not have a well-defined behavior of what would happen with any time information
-   * beyond millisecond precision. This could cause some values with more than millisecond precision
-   * to be rounded up instead of truncated.
+   * <p>Any time information beyond millisecond precision is truncated.
    *
    * <p>For the date-only case, the time zone is ignored and the hourOfDay, minute, second, and
    * millisecond parameters are set to zero.
@@ -284,12 +281,12 @@ public final class DateTime implements Serializable {
    * Parses an RFC3339 timestamp to a pair of seconds and nanoseconds since Unix Epoch.
    *
    * @param str Date/time string in RFC3339 format
-   * @throws NumberFormatException if {@code str} doesn't match the RFC3339 standard format; an
+   * @throws IllegalArgumentException if {@code str} doesn't match the RFC3339 standard format; an
    *     exception is thrown if {@code str} doesn't match {@code RFC3339_REGEX} or if it contains a
    *     time zone shift but no time.
    */
   public static SecondsAndNanos parseRfc3339ToSecondsAndNanos(String str)
-      throws NumberFormatException {
+      throws IllegalArgumentException {
     return parseRfc3339WithNanoSeconds(str).toSecondsAndNanos();
   }
 

--- a/google-http-client/src/test/java/com/google/api/client/util/DateTimeTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/DateTimeTest.java
@@ -229,8 +229,8 @@ public class DateTimeTest extends TestCase {
   private void assertParsedRfc3339(String input, SecondsAndNanos expected) {
     SecondsAndNanos actual = DateTime.parseRfc3339ToSecondsAndNanos(input);
     assertEquals(
-        "Seconds for " + input + " do not match", actual.getSeconds(), expected.getSeconds());
-    assertEquals("Nanos for " + input + " do not match", actual.getNanos(), expected.getNanos());
+        "Seconds for " + input + " do not match", expected.getSeconds(), actual.getSeconds());
+    assertEquals("Nanos for " + input + " do not match", expected.getNanos(), actual.getNanos());
   }
 
   public void testParseAndFormatRfc3339() {

--- a/google-http-client/src/test/java/com/google/api/client/util/DateTimeTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/DateTimeTest.java
@@ -14,10 +14,6 @@
 
 package com.google.api.client.util;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
 import com.google.api.client.util.DateTime.SecondsAndNanos;
 import java.util.Date;
 import java.util.HashMap;
@@ -155,7 +151,7 @@ public class DateTimeTest extends TestCase {
     assertEquals(
         DateTime.parseRfc3339(
             "2018-12-31T23:59:59.999999999Z"), // This value would be rounded up prior to version
-                                               // 1.30.2
+        // 1.30.2
         DateTime.parseRfc3339("2018-12-31T23:59:59.999Z"));
     assertEquals(
         DateTime.parseRfc3339(
@@ -224,14 +220,14 @@ public class DateTimeTest extends TestCase {
 
     for (Entry<String, SecondsAndNanos> entry : map.entrySet()) {
       SecondsAndNanos gTimestamp = DateTime.parseRfc3339ToSecondsAndNanos(entry.getKey());
-      assertThat(
+      assertEquals(
           "Seconds for " + entry + " do not match",
           gTimestamp.getSeconds(),
-          is(equalTo(entry.getValue().getSeconds())));
-      assertThat(
+          entry.getValue().getSeconds());
+      assertEquals(
           "Nanos for " + entry + " do not match",
           gTimestamp.getNanos(),
-          is(equalTo(entry.getValue().getNanos())));
+          entry.getValue().getNanos());
     }
   }
 

--- a/google-http-client/src/test/java/com/google/api/client/util/DateTimeTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/DateTimeTest.java
@@ -14,7 +14,15 @@
 
 package com.google.api.client.util;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.api.client.util.DateTime.SecondsAndNanos;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TimeZone;
 import junit.framework.TestCase;
 
@@ -142,6 +150,89 @@ public class DateTimeTest extends TestCase {
     assertEquals(
         DateTime.parseRfc3339("2007-06-01t18:50:00-04:00").getValue(),
         DateTime.parseRfc3339("2007-06-01t22:50:00Z").getValue()); // from Section 4.2 Local Offsets
+
+    // Test truncating beyond millisecond precision.
+    assertEquals(
+        DateTime.parseRfc3339(
+            "2018-12-31T23:59:59.999999999Z"), // This value would be rounded up prior to version
+                                               // 1.30.2
+        DateTime.parseRfc3339("2018-12-31T23:59:59.999Z"));
+    assertEquals(
+        DateTime.parseRfc3339(
+            "2018-12-31T23:59:59.9999Z"), // This value would be truncated prior to version 1.30.2
+        DateTime.parseRfc3339("2018-12-31T23:59:59.999Z"));
+  }
+
+  /**
+   * The following test values have been generated and verified using the {@link DateTimeFormatter}
+   * in Java 8.
+   *
+   * <pre>
+   * Timestamp                           |   Seconds     |   Nanos
+   * 2018-03-01T10:11:12.999Z            |   1519899072  |   999000000
+   * 2018-10-28T02:00:00+02:00           |   1540684800  |   0
+   * 2018-10-28T03:00:00+01:00           |   1540692000  |   0
+   * 2018-01-01T00:00:00.000000001Z      |   1514764800  |   1
+   * 2018-10-28T02:00:00Z                |   1540692000  |   0
+   * 2018-12-31T23:59:59.999999999Z      |   1546300799  |   999999999
+   * 2018-03-01T10:11:12.9999Z           |   1519899072  |   999900000
+   * 2018-03-01T10:11:12.000000001Z      |   1519899072  |   1
+   * 2018-03-01T10:11:12.100000000Z      |   1519899072  |   100000000
+   * 2018-03-01T10:11:12.100000001Z      |   1519899072  |   100000001
+   * 2018-03-01T10:11:12-10:00           |   1519935072  |   0
+   * 2018-03-01T10:11:12.999999999Z      |   1519899072  |   999999999
+   * 2018-03-01T10:11:12-12:00           |   1519942272  |   0
+   * 2018-10-28T03:00:00Z                |   1540695600  |   0
+   * 2018-10-28T02:30:00Z                |   1540693800  |   0
+   * 2018-03-01T10:11:12.123Z            |   1519899072  |   123000000
+   * 2018-10-28T02:30:00+02:00           |   1540686600  |   0
+   * 2018-03-01T10:11:12.123456789Z      |   1519899072  |   123456789
+   * 2018-03-01T10:11:12.1000Z           |   1519899072  |   100000000
+   * </pre>
+   */
+  public void testParseRfc3339ToSecondsAndNanos() {
+    Map<String, SecondsAndNanos> map = new HashMap<>();
+    map.put("2018-03-01T10:11:12.999Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 999000000));
+    map.put("2018-10-28T02:00:00+02:00", SecondsAndNanos.ofSecondsAndNanos(1540684800L, 0));
+    map.put("2018-10-28T03:00:00+01:00", SecondsAndNanos.ofSecondsAndNanos(1540692000L, 0));
+    map.put("2018-01-01T00:00:00.000000001Z", SecondsAndNanos.ofSecondsAndNanos(1514764800L, 1));
+    map.put("2018-10-28T02:00:00Z", SecondsAndNanos.ofSecondsAndNanos(1540692000L, 0));
+    map.put(
+        "2018-12-31T23:59:59.999999999Z",
+        SecondsAndNanos.ofSecondsAndNanos(1546300799L, 999999999));
+    map.put("2018-03-01T10:11:12.9999Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 999900000));
+    map.put("2018-03-01T10:11:12.000000001Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 1));
+    map.put(
+        "2018-03-01T10:11:12.100000000Z",
+        SecondsAndNanos.ofSecondsAndNanos(1519899072L, 100000000));
+    map.put(
+        "2018-03-01T10:11:12.100000001Z",
+        SecondsAndNanos.ofSecondsAndNanos(1519899072L, 100000001));
+    map.put("2018-03-01T10:11:12-10:00", SecondsAndNanos.ofSecondsAndNanos(1519935072L, 0));
+    map.put(
+        "2018-03-01T10:11:12.999999999Z",
+        SecondsAndNanos.ofSecondsAndNanos(1519899072L, 999999999));
+    map.put("2018-03-01T10:11:12-12:00", SecondsAndNanos.ofSecondsAndNanos(1519942272L, 0));
+    map.put("2018-10-28T03:00:00Z", SecondsAndNanos.ofSecondsAndNanos(1540695600L, 0));
+    map.put("2018-10-28T02:30:00Z", SecondsAndNanos.ofSecondsAndNanos(1540693800L, 0));
+    map.put("2018-03-01T10:11:12.123Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 123000000));
+    map.put("2018-10-28T02:30:00+02:00", SecondsAndNanos.ofSecondsAndNanos(1540686600L, 0));
+    map.put(
+        "2018-03-01T10:11:12.123456789Z",
+        SecondsAndNanos.ofSecondsAndNanos(1519899072L, 123456789));
+    map.put("2018-03-01T10:11:12.1000Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 100000000));
+
+    for (Entry<String, SecondsAndNanos> entry : map.entrySet()) {
+      SecondsAndNanos gTimestamp = DateTime.parseRfc3339ToSecondsAndNanos(entry.getKey());
+      assertThat(
+          "Seconds for " + entry + " do not match",
+          gTimestamp.getSeconds(),
+          is(equalTo(entry.getValue().getSeconds())));
+      assertThat(
+          "Nanos for " + entry + " do not match",
+          gTimestamp.getNanos(),
+          is(equalTo(entry.getValue().getNanos())));
+    }
   }
 
   public void testParseAndFormatRfc3339() {

--- a/google-http-client/src/test/java/com/google/api/client/util/DateTimeTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/DateTimeTest.java
@@ -16,9 +16,6 @@ package com.google.api.client.util;
 
 import com.google.api.client.util.DateTime.SecondsAndNanos;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.TimeZone;
 import junit.framework.TestCase;
 
@@ -187,48 +184,53 @@ public class DateTimeTest extends TestCase {
    * </pre>
    */
   public void testParseRfc3339ToSecondsAndNanos() {
-    Map<String, SecondsAndNanos> map = new HashMap<>();
-    map.put("2018-03-01T10:11:12.999Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 999000000));
-    map.put("2018-10-28T02:00:00+02:00", SecondsAndNanos.ofSecondsAndNanos(1540684800L, 0));
-    map.put("2018-10-28T03:00:00+01:00", SecondsAndNanos.ofSecondsAndNanos(1540692000L, 0));
-    map.put("2018-01-01T00:00:00.000000001Z", SecondsAndNanos.ofSecondsAndNanos(1514764800L, 1));
-    map.put("2018-10-28T02:00:00Z", SecondsAndNanos.ofSecondsAndNanos(1540692000L, 0));
-    map.put(
+    assertParsedRfc3339(
+        "2018-03-01T10:11:12.999Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 999000000));
+    assertParsedRfc3339(
+        "2018-10-28T02:00:00+02:00", SecondsAndNanos.ofSecondsAndNanos(1540684800L, 0));
+    assertParsedRfc3339(
+        "2018-10-28T03:00:00+01:00", SecondsAndNanos.ofSecondsAndNanos(1540692000L, 0));
+    assertParsedRfc3339(
+        "2018-01-01T00:00:00.000000001Z", SecondsAndNanos.ofSecondsAndNanos(1514764800L, 1));
+    assertParsedRfc3339("2018-10-28T02:00:00Z", SecondsAndNanos.ofSecondsAndNanos(1540692000L, 0));
+    assertParsedRfc3339(
         "2018-12-31T23:59:59.999999999Z",
         SecondsAndNanos.ofSecondsAndNanos(1546300799L, 999999999));
-    map.put("2018-03-01T10:11:12.9999Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 999900000));
-    map.put("2018-03-01T10:11:12.000000001Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 1));
-    map.put(
+    assertParsedRfc3339(
+        "2018-03-01T10:11:12.9999Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 999900000));
+    assertParsedRfc3339(
+        "2018-03-01T10:11:12.000000001Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 1));
+    assertParsedRfc3339(
         "2018-03-01T10:11:12.100000000Z",
         SecondsAndNanos.ofSecondsAndNanos(1519899072L, 100000000));
-    map.put(
+    assertParsedRfc3339(
         "2018-03-01T10:11:12.100000001Z",
         SecondsAndNanos.ofSecondsAndNanos(1519899072L, 100000001));
-    map.put("2018-03-01T10:11:12-10:00", SecondsAndNanos.ofSecondsAndNanos(1519935072L, 0));
-    map.put(
+    assertParsedRfc3339(
+        "2018-03-01T10:11:12-10:00", SecondsAndNanos.ofSecondsAndNanos(1519935072L, 0));
+    assertParsedRfc3339(
         "2018-03-01T10:11:12.999999999Z",
         SecondsAndNanos.ofSecondsAndNanos(1519899072L, 999999999));
-    map.put("2018-03-01T10:11:12-12:00", SecondsAndNanos.ofSecondsAndNanos(1519942272L, 0));
-    map.put("2018-10-28T03:00:00Z", SecondsAndNanos.ofSecondsAndNanos(1540695600L, 0));
-    map.put("2018-10-28T02:30:00Z", SecondsAndNanos.ofSecondsAndNanos(1540693800L, 0));
-    map.put("2018-03-01T10:11:12.123Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 123000000));
-    map.put("2018-10-28T02:30:00+02:00", SecondsAndNanos.ofSecondsAndNanos(1540686600L, 0));
-    map.put(
+    assertParsedRfc3339(
+        "2018-03-01T10:11:12-12:00", SecondsAndNanos.ofSecondsAndNanos(1519942272L, 0));
+    assertParsedRfc3339("2018-10-28T03:00:00Z", SecondsAndNanos.ofSecondsAndNanos(1540695600L, 0));
+    assertParsedRfc3339("2018-10-28T02:30:00Z", SecondsAndNanos.ofSecondsAndNanos(1540693800L, 0));
+    assertParsedRfc3339(
+        "2018-03-01T10:11:12.123Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 123000000));
+    assertParsedRfc3339(
+        "2018-10-28T02:30:00+02:00", SecondsAndNanos.ofSecondsAndNanos(1540686600L, 0));
+    assertParsedRfc3339(
         "2018-03-01T10:11:12.123456789Z",
         SecondsAndNanos.ofSecondsAndNanos(1519899072L, 123456789));
-    map.put("2018-03-01T10:11:12.1000Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 100000000));
+    assertParsedRfc3339(
+        "2018-03-01T10:11:12.1000Z", SecondsAndNanos.ofSecondsAndNanos(1519899072L, 100000000));
+  }
 
-    for (Entry<String, SecondsAndNanos> entry : map.entrySet()) {
-      SecondsAndNanos gTimestamp = DateTime.parseRfc3339ToSecondsAndNanos(entry.getKey());
-      assertEquals(
-          "Seconds for " + entry + " do not match",
-          gTimestamp.getSeconds(),
-          entry.getValue().getSeconds());
-      assertEquals(
-          "Nanos for " + entry + " do not match",
-          gTimestamp.getNanos(),
-          entry.getValue().getNanos());
-    }
+  private void assertParsedRfc3339(String input, SecondsAndNanos expected) {
+    SecondsAndNanos actual = DateTime.parseRfc3339ToSecondsAndNanos(input);
+    assertEquals(
+        "Seconds for " + input + " do not match", actual.getSeconds(), expected.getSeconds());
+    assertEquals("Nanos for " + input + " do not match", actual.getNanos(), expected.getNanos());
   }
 
   public void testParseAndFormatRfc3339() {


### PR DESCRIPTION
The original parseRfc3339 method of `DateTime` returns a `DateTime` instance that has millisecond precision. The parse method therefore also disregards any time information beyond millisecond precision. For Spanner we would like to add nanosecond precision, and instead of replicating the parse method in the Spanner specific libraries, this change will add nanosecond support to this parse method, while retaining the original behavior of the parseRfc3339 method.

The original parseRfc3339 method allows strings to contain more than millisecond precision. It does however not specify exactly what it does with any additional information, and the behavior is not consistent:
* The input value `2018-12-31T23:59:59.9999Z` would be truncated to `2018-12-31T23:59:59.999Z`
* The input value `2018-12-31T23:59:59.999999999Z` would be rounded up to `2019-01-01T00:00:00Z`

After this change the method will always truncate any time information beyond millisecond precision when returning a `DateTime` instance.