### PR TITLE
Release google-http-java-client v1.31.0

### DIFF
--- a/google-http-client-android-test/pom.xml
+++ b/google-http-client-android-test/pom.xml
@@ -4,7 +4,7 @@
   <groupId>google-http-client</groupId>
   <artifactId>google-http-client-android-test</artifactId>
   <name>Test project for google-http-client-android.</name>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-android-test:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-android-test:current} -->
   <packaging>apk</packaging>
 
   <build>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-android</artifactId>
-      <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+      <version>1.31.0</version><!-- {x-version-update:google-http-client-android:current} -->
       <exclusions>
         <exclusion>
           <artifactId>android</artifactId>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-test</artifactId>
-      <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+      <version>1.31.0</version><!-- {x-version-update:google-http-client-test:current} -->
       <exclusions>
         <exclusion>
           <artifactId>junit</artifactId>

--- a/google-http-client-android/pom.xml
+++ b/google-http-client-android/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-android</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-android:current} -->
   <name>Android Platform Extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-apache-v2/pom.xml
+++ b/google-http-client-apache-v2/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-apache-v2</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-apache-v2:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-apache-v2:current} -->
   <name>Apache HTTP transport v2 for the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-appengine/pom.xml
+++ b/google-http-client-appengine/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-appengine</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-appengine:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-appengine:current} -->
   <name>Google App Engine extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-assembly/pom.xml
+++ b/google-http-client-assembly/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-assembly</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-assembly:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-assembly:current} -->
   <packaging>pom</packaging>
   <name>Assembly for the Google HTTP Client Library for Java</name>
 

--- a/google-http-client-bom/README.md
+++ b/google-http-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-bom</artifactId>
-      <version>1.30.1</version>
+      <version>1.31.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-http-client-bom/pom.xml
+++ b/google-http-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-bom</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-bom:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-bom:current} -->
   <packaging>pom</packaging>
 
   <name>Google HTTP Client Library for Java BOM</name>
@@ -63,52 +63,52 @@
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client</artifactId>
-        <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client:current} -->
+        <version>1.31.0</version><!-- {x-version-update:google-http-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-android</artifactId>
-        <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+        <version>1.31.0</version><!-- {x-version-update:google-http-client-android:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-apache-v2</artifactId>
-        <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-apache-v2:current} -->
+        <version>1.31.0</version><!-- {x-version-update:google-http-client-apache-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-appengine</artifactId>
-        <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-appengine:current} -->
+        <version>1.31.0</version><!-- {x-version-update:google-http-client-appengine:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-findbugs</artifactId>
-        <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-findbugs:current} -->
+        <version>1.31.0</version><!-- {x-version-update:google-http-client-findbugs:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-gson</artifactId>
-        <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-gson:current} -->
+        <version>1.31.0</version><!-- {x-version-update:google-http-client-gson:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-jackson2</artifactId>
-        <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson2:current} -->
+        <version>1.31.0</version><!-- {x-version-update:google-http-client-jackson2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-protobuf</artifactId>
-        <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-protobuf:current} -->
+        <version>1.31.0</version><!-- {x-version-update:google-http-client-protobuf:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-test</artifactId>
-        <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+        <version>1.31.0</version><!-- {x-version-update:google-http-client-test:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-xml</artifactId>
-        <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-xml:current} -->
+        <version>1.31.0</version><!-- {x-version-update:google-http-client-xml:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-http-client-findbugs/pom.xml
+++ b/google-http-client-findbugs/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-findbugs</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-findbugs:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-findbugs:current} -->
   <name>Google APIs Client Library Findbugs custom plugin.</name>
 
   <build>

--- a/google-http-client-gson/pom.xml
+++ b/google-http-client-gson/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-gson</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-gson:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-gson:current} -->
   <name>GSON extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-jackson2/pom.xml
+++ b/google-http-client-jackson2/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jackson2</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson2:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-jackson2:current} -->
   <name>Jackson 2 extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-protobuf/pom.xml
+++ b/google-http-client-protobuf/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-protobuf</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-protobuf:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-protobuf:current} -->
   <name>Protocol Buffer extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-test/pom.xml
+++ b/google-http-client-test/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-test</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-test:current} -->
   <name>Shared classes used for testing of artifacts in the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-xml/pom.xml
+++ b/google-http-client-xml/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-xml</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-xml:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-xml:current} -->
   <name>XML extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client:current} -->
   <name>Google HTTP Client Library for Java</name>
   <description>
     Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-parent</artifactId>
-  <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+  <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google HTTP Client Library for Java</name>
 
@@ -551,7 +551,7 @@
       - google-api-java-client/google-api-client-assembly/android-properties (make the filenames match the version here)
       - Internally, update the default features.json file
     -->
-    <project.http-client.version>1.30.2-SNAPSHOT</project.http-client.version><!-- {x-version-update:google-http-client-parent:current} -->
+    <project.http-client.version>1.31.0</project.http-client.version><!-- {x-version-update:google-http-client-parent:current} -->
     <project.appengine.version>1.9.71</project.appengine.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.jsr305.version>3.0.2</project.jsr305.version>

--- a/samples/dailymotion-simple-cmdline-sample/pom.xml
+++ b/samples/dailymotion-simple-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.30.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.31.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>dailymotion-simple-cmdline-sample</artifactId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,18 +1,18 @@
 # Format:
 # module:released-version:current-version
 
-google-http-client:1.30.1:1.30.2-SNAPSHOT
-google-http-client-bom:1.30.1:1.30.2-SNAPSHOT
-google-http-client-parent:1.30.1:1.30.2-SNAPSHOT
-google-http-client-android:1.30.1:1.30.2-SNAPSHOT
-google-http-client-android-test:1.30.1:1.30.2-SNAPSHOT
-google-http-client-apache-v2:1.30.1:1.30.2-SNAPSHOT
-google-http-client-appengine:1.30.1:1.30.2-SNAPSHOT
-google-http-client-assembly:1.30.1:1.30.2-SNAPSHOT
-google-http-client-findbugs:1.30.1:1.30.2-SNAPSHOT
-google-http-client-gson:1.30.1:1.30.2-SNAPSHOT
-google-http-client-jackson2:1.30.1:1.30.2-SNAPSHOT
-google-http-client-jdo:1.30.1:1.30.2-SNAPSHOT
-google-http-client-protobuf:1.30.1:1.30.2-SNAPSHOT
-google-http-client-test:1.30.1:1.30.2-SNAPSHOT
-google-http-client-xml:1.30.1:1.30.2-SNAPSHOT
+google-http-client:1.31.0:1.31.0
+google-http-client-bom:1.31.0:1.31.0
+google-http-client-parent:1.31.0:1.31.0
+google-http-client-android:1.31.0:1.31.0
+google-http-client-android-test:1.31.0:1.31.0
+google-http-client-apache-v2:1.31.0:1.31.0
+google-http-client-appengine:1.31.0:1.31.0
+google-http-client-assembly:1.31.0:1.31.0
+google-http-client-findbugs:1.31.0:1.31.0
+google-http-client-gson:1.31.0:1.31.0
+google-http-client-jackson2:1.31.0:1.31.0
+google-http-client-jdo:1.31.0:1.31.0
+google-http-client-protobuf:1.31.0:1.31.0
+google-http-client-test:1.31.0:1.31.0
+google-http-client-xml:1.31.0:1.31.0


### PR DESCRIPTION
This pull request was generated using releasetool.

07-31-2019 07:21 PDT


### Implementation Changes
- Fix ApacheHttpTransport configuration ([#717](https://github.com/googleapis/google-http-java-client/pull/717))

### New Features
- Add support for nanosecond precision when parsing rfc3339 strings ([#752](https://github.com/googleapis/google-http-java-client/pull/752))
- Use NIO to set file permissions ([#557](https://github.com/googleapis/google-http-java-client/pull/557))
- Expose the default HttpClientBuilder so users can customize further ([#713](https://github.com/googleapis/google-http-java-client/pull/713))

### Dependencies
- Update dependency org.apache.maven.plugins:maven-site-plugin to v3.8.2 ([#753](https://github.com/googleapis/google-http-java-client/pull/753))
- Update dependency mysql:mysql-connector-java to v8.0.17 ([#750](https://github.com/googleapis/google-http-java-client/pull/750))
- Update dependency com.google.truth:truth to v1 ([#742](https://github.com/googleapis/google-http-java-client/pull/742))
- Update dependency org.apache.maven.plugins:maven-javadoc-plugin to v3.1.1 ([#741](https://github.com/googleapis/google-http-java-client/pull/741))
- Update dependency com.google.truth:truth to v0.46 ([#724](https://github.com/googleapis/google-http-java-client/pull/724))
- Update dependency org.apache.httpcomponents:httpclient to v4.5.9 ([#704](https://github.com/googleapis/google-http-java-client/pull/704))
- Group Guava, AppEngine, OpenCensus dependencies for renovate

### Documentation
- Add GitHub repo, issue tracker metadata for javadoc site ([#721](https://github.com/googleapis/google-http-java-client/pull/721))
- Clean up javadoc warnings in OpenCensusUtils ([#714](https://github.com/googleapis/google-http-java-client/pull/714))

### Internal / Testing Changes
- Adds CI test for mvn dependency:analyze and fixes missing deps ([#738](https://github.com/googleapis/google-http-java-client/pull/738))
- Configure Kokoro CI for Windows ([#716](https://github.com/googleapis/google-http-java-client/pull/716))
- Add Linkage Monitor presubmit check ([#719](https://github.com/googleapis/google-http-java-client/pull/719))
- Enable autorelease ([#703](https://github.com/googleapis/google-http-java-client/pull/703))
- new ClassName().getClass() -> ClassName.class ([#751](https://github.com/googleapis/google-http-java-client/pull/751))
