### PR TITLE
Surface rawToken for JWT wrapper

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/json/webtoken/JsonWebSignature.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/webtoken/JsonWebSignature.java
@@ -482,6 +482,11 @@ public class JsonWebSignature extends JsonWebToken {
     return signedContentBytes;
   }
 
+  /** Returns the URLsafe base64 encoded JWS token */
+  public String getRawToken() {
+    return super.getRawToken() + "." + Base64.encodeBase64URLSafeString(getSignatureBytes());
+  }
+
   /**
    * Parses the given JWS token string and returns the parsed {@link JsonWebSignature}.
    *

--- a/google-http-client/src/main/java/com/google/api/client/json/webtoken/JsonWebSignature.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/webtoken/JsonWebSignature.java
@@ -482,7 +482,7 @@ public class JsonWebSignature extends JsonWebToken {
     return signedContentBytes;
   }
 
-  /** Returns the URLsafe base64 encoded JWS token */
+  /** Returns the URL safe Base64 encoded JWS token. */
   public String getRawToken() {
     return super.getRawToken() + "." + Base64.encodeBase64URLSafeString(getSignatureBytes());
   }

--- a/google-http-client/src/main/java/com/google/api/client/json/webtoken/JsonWebToken.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/webtoken/JsonWebToken.java
@@ -15,6 +15,7 @@
 package com.google.api.client.json.webtoken;
 
 import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Base64;
 import com.google.api.client.util.Key;
 import com.google.api.client.util.Objects;
 import com.google.api.client.util.Preconditions;
@@ -359,6 +360,12 @@ public class JsonWebToken {
   @Override
   public String toString() {
     return Objects.toStringHelper(this).add("header", header).add("payload", payload).toString();
+  }
+
+  public String getRawToken() {
+    return Base64.encodeBase64URLSafeString(header.toString().getBytes())
+        + "."
+        + Base64.encodeBase64URLSafeString(payload.toString().getBytes());
   }
 
   /**

--- a/google-http-client/src/test/java/com/google/api/client/json/webtoken/JsonWebSignatureTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/json/webtoken/JsonWebSignatureTest.java
@@ -49,8 +49,8 @@ public class JsonWebSignatureTest extends TestCase {
   public void testRawToken() throws Exception {
     String rawToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikp"
         + "vaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
-    JsonWebSignature jws = JsonWebSignature.parse(new MockJsonFactory(), rawToken);
-    assertEquals(jws.getRawToken(), rawToken);
+    JsonWebSignature signature = JsonWebSignature.parse(new MockJsonFactory(), rawToken);
+    assertEquals(signature.getRawToken(), rawToken);
   }
 
   private X509Certificate verifyX509WithCaCert(TestCertificates.CertData caCert) throws Exception {

--- a/google-http-client/src/test/java/com/google/api/client/json/webtoken/JsonWebSignatureTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/json/webtoken/JsonWebSignatureTest.java
@@ -46,6 +46,13 @@ public class JsonWebSignatureTest extends TestCase {
         JsonWebSignature.signUsingRsaSha256(privateKey, new MockJsonFactory(), header, payload));
   }
 
+  public void testRawToken() throws Exception {
+    String rawToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikp"
+        + "vaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    JsonWebSignature jws = JsonWebSignature.parse(new MockJsonFactory(), rawToken);
+    assertEquals(jws.getRawToken(), rawToken);
+  }
+
   private X509Certificate verifyX509WithCaCert(TestCertificates.CertData caCert) throws Exception {
     JsonWebSignature signature = TestCertificates.getJsonWebSignature();
     X509TrustManager trustManager = caCert.getTrustManager();


### PR DESCRIPTION
Adds ability to recall the raw JWT encoded token from `JsonWebSignature` and `JsonWebToken`.

The current .`toString()` method for both classes returns a JSON object.  Its useful to have access to the raw token directly to be used in an http client (as `Authorization: Bearer <rawToken>`, for example)

ref:
  https://github.com/googleapis/google-auth-library-java/pull/303#pullrequestreview-269723158