### PR TITLE
Remove google-http-client-jdo

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -12,7 +12,6 @@ google-http-client-assembly:1.31.0:1.31.1-SNAPSHOT
 google-http-client-findbugs:1.31.0:1.31.1-SNAPSHOT
 google-http-client-gson:1.31.0:1.31.1-SNAPSHOT
 google-http-client-jackson2:1.31.0:1.31.1-SNAPSHOT
-google-http-client-jdo:1.31.0:1.31.1-SNAPSHOT
 google-http-client-protobuf:1.31.0:1.31.1-SNAPSHOT
 google-http-client-test:1.31.0:1.31.1-SNAPSHOT
 google-http-client-xml:1.31.0:1.31.1-SNAPSHOT


### PR DESCRIPTION
Last release was 1.28.0. Then it was deleted.