### PR TITLE
Remove deprecated testing method

### DIFF
--- a/clirr-ignored-differences.xml
+++ b/clirr-ignored-differences.xml
@@ -2,6 +2,11 @@
 <!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
 
 <differences>
+   <difference>
+     <differenceType>7002</differenceType>
+     <className>com/google/api/client/testing/http/MockHttpTransport</className>
+     <method>com.google.api.client.testing.http.MockHttpTransport$Builder builder()</method>
+  </difference>
   <!-- 8001 (Class removed): className -->
   <difference>
     <differenceType>8001</differenceType>

--- a/google-http-client/src/main/java/com/google/api/client/testing/http/MockHttpTransport.java
+++ b/google-http-client/src/main/java/com/google/api/client/testing/http/MockHttpTransport.java
@@ -100,19 +100,6 @@ public class MockHttpTransport extends HttpTransport {
   }
 
   /**
-   * Returns an instance of a new builder.
-   *
-   * <p>
-   *
-   * @deprecated (to be removed in the future) Use {@link Builder#Builder()} instead.
-   * @since 1.5
-   */
-  @Deprecated
-  public static Builder builder() {
-    return new Builder();
-  }
-
-  /**
    * {@link Beta} <br>
    * Builder for {@link MockHttpTransport}.
    *


### PR DESCRIPTION
Fixes #772 @chingor13 

Noticed this one because of a warning in the build