### PR TITLE
fix import order warnings

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -57,6 +57,12 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="tokens" value="STATIC_IMPORT, IMPORT"/>
     </module>
 
+    <module name="CustomImportOrder">
+      <property name="sortImportsInGroupAlphabetically" value="true"/>
+      <property name="separateLineBetweenGroups" value="true"/>
+      <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+    </module>
+
     <!--
 
     JAVADOC CHECKS

--- a/google-http-client/src/main/java/com/google/api/client/http/apache/SSLSocketFactoryExtension.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/apache/SSLSocketFactoryExtension.java
@@ -28,7 +28,7 @@ import org.apache.http.conn.ssl.SSLSocketFactory;
 
 /**
  * Implementation of SSL socket factory that extends Apache's implementation to provide
- * functionality missing from the Android SDK that  is available in Apache HTTP Client.
+ * functionality missing from the Android SDK that is available in Apache HTTP Client.
  *
  * @author Yaniv Inbar
  */

--- a/google-http-client/src/main/java/com/google/api/client/http/apache/SSLSocketFactoryExtension.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/apache/SSLSocketFactoryExtension.java
@@ -28,7 +28,7 @@ import org.apache.http.conn.ssl.SSLSocketFactory;
 
 /**
  * Implementation of SSL socket factory that extends Apache's implementation to provide
- * functionality missing from the Android SDK that is available in Apache HTTP Client.
+ * functionality missing from the Android SDK that  is available in Apache HTTP Client.
  *
  * @author Yaniv Inbar
  */


### PR DESCRIPTION
Fixes #771 @kolea2 

This updates the checkstyle config to the current Google import style, though longer term we should think about updating to the full set of google style at https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml 