### PR TITLE
remove obsolete and deprecated parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,11 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-parent</artifactId>
   <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->


### PR DESCRIPTION
Per https://github.com/sonatype/oss-parents

"This project is no longer active or supported. We suggest to manage parent POM files for your own organization as needed. The POM files from this project no longer work with latest Maven and/or Java versions."