### PR TITLE
fix: grab version from the package metadata

### DIFF
--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -30,6 +30,17 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>resources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
@@ -55,7 +66,10 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
-          <archive>  
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
             <manifestEntries>
               <Automatic-Module-Name>com.google.api.client</Automatic-Module-Name>
@@ -78,6 +92,13 @@
         </executions>
       </plugin>
     </plugins>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
   </build>
   <dependencies>
     <dependency>

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -30,6 +30,7 @@ import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracer;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -1203,6 +1204,20 @@ public final class HttpRequest {
   }
   
   private static String getVersion() {
-    return HttpRequest.class.getPackage().getImplementationVersion();
+    String version = HttpRequest.class.getPackage().getImplementationVersion();
+    // in a non-packaged environment (local), there's no implementation version to read
+    if (version == null) {
+      // fall back to reading from a properties file - note this value is expected to be cached
+      try (InputStream inputStream = HttpRequest.class.getResourceAsStream("/google-http-client.properties")) {
+        if (inputStream != null) {
+          Properties properties = new Properties();
+          properties.load(inputStream);
+          version = properties.getProperty("google-http-client.version");
+        }
+      } catch (IOException e) {
+        // ignore
+      }
+    }
+    return version;
   }
 }

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -53,7 +53,7 @@ public final class HttpRequest {
    *
    * @since 1.8
    */
-  public static final String VERSION = "1.30.0";
+  public static final String VERSION = getVersion();
 
   /**
    * User agent suffix for all requests.
@@ -1200,5 +1200,9 @@ public final class HttpRequest {
     if (value != null) {
       span.putAttribute(key, AttributeValue.stringAttributeValue(value));
     }
+  }
+  
+  private static String getVersion() {
+    return HttpRequest.class.getPackage().getImplementationVersion();
   }
 }

--- a/google-http-client/src/main/resources/google-http-client.properties
+++ b/google-http-client/src/main/resources/google-http-client.properties
@@ -1,0 +1,1 @@
+google-http-client.version=${project.version}

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTest.java
@@ -1092,6 +1092,7 @@ public class HttpRequestTest extends TestCase {
   }
 
   public void testVersion() {
+    assertNotNull("version constant should not be null", HttpRequest.VERSION);
     Pattern semverPattern = Pattern.compile("\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?");
     assertTrue(semverPattern.matcher(HttpRequest.VERSION).matches());
   }

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
+import java.util.regex.Pattern;
 import junit.framework.TestCase;
 
 import java.io.ByteArrayInputStream;
@@ -1088,6 +1089,11 @@ public class HttpRequestTest extends TestCase {
     } catch (IllegalArgumentException e) {
       // Expected
     }
+  }
+
+  public void testVersion() {
+    Pattern semverPattern = Pattern.compile("\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?");
+    assertTrue(semverPattern.matcher(HttpRequest.VERSION).matches());
   }
 
   public void testUserAgent() {

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,11 @@
           <artifactId>maven-dependency-plugin</artifactId>
           <version>3.1.1</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
Fixes #796

This PR allows the HttpClient to inspect its own version at start time. If it's running from a package, it can fetch the version from the package manifest's implementation version. If it's not, it can read it from a properties file created at compile time to read the version.

Note that this is similar to how gax inspects its own version for the x-goog-api-client header