### PR TITLE
Release google-http-java-client v1.32.0

### DIFF
--- a/google-http-client-android-test/pom.xml
+++ b/google-http-client-android-test/pom.xml
@@ -4,7 +4,7 @@
   <groupId>google-http-client</groupId>
   <artifactId>google-http-client-android-test</artifactId>
   <name>Test project for google-http-client-android.</name>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-android-test:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-android-test:current} -->
   <packaging>apk</packaging>
 
   <build>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-android</artifactId>
-      <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+      <version>1.32.0</version><!-- {x-version-update:google-http-client-android:current} -->
       <exclusions>
         <exclusion>
           <artifactId>android</artifactId>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-test</artifactId>
-      <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+      <version>1.32.0</version><!-- {x-version-update:google-http-client-test:current} -->
       <exclusions>
         <exclusion>
           <artifactId>junit</artifactId>

--- a/google-http-client-android/pom.xml
+++ b/google-http-client-android/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-android</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-android:current} -->
   <name>Android Platform Extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-apache-v2/pom.xml
+++ b/google-http-client-apache-v2/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-apache-v2</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-apache-v2:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-apache-v2:current} -->
   <name>Apache HTTP transport v2 for the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-appengine/pom.xml
+++ b/google-http-client-appengine/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-appengine</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-appengine:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-appengine:current} -->
   <name>Google App Engine extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-assembly/pom.xml
+++ b/google-http-client-assembly/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-assembly</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-assembly:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-assembly:current} -->
   <packaging>pom</packaging>
   <name>Assembly for the Google HTTP Client Library for Java</name>
 

--- a/google-http-client-bom/README.md
+++ b/google-http-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-bom</artifactId>
-      <version>1.31.0</version>
+      <version>1.32.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-http-client-bom/pom.xml
+++ b/google-http-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-bom</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-bom:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-bom:current} -->
   <packaging>pom</packaging>
 
   <name>Google HTTP Client Library for Java BOM</name>
@@ -63,52 +63,52 @@
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client</artifactId>
-        <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client:current} -->
+        <version>1.32.0</version><!-- {x-version-update:google-http-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-android</artifactId>
-        <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-android:current} -->
+        <version>1.32.0</version><!-- {x-version-update:google-http-client-android:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-apache-v2</artifactId>
-        <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-apache-v2:current} -->
+        <version>1.32.0</version><!-- {x-version-update:google-http-client-apache-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-appengine</artifactId>
-        <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-appengine:current} -->
+        <version>1.32.0</version><!-- {x-version-update:google-http-client-appengine:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-findbugs</artifactId>
-        <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-findbugs:current} -->
+        <version>1.32.0</version><!-- {x-version-update:google-http-client-findbugs:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-gson</artifactId>
-        <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-gson:current} -->
+        <version>1.32.0</version><!-- {x-version-update:google-http-client-gson:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-jackson2</artifactId>
-        <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson2:current} -->
+        <version>1.32.0</version><!-- {x-version-update:google-http-client-jackson2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-protobuf</artifactId>
-        <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-protobuf:current} -->
+        <version>1.32.0</version><!-- {x-version-update:google-http-client-protobuf:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-test</artifactId>
-        <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+        <version>1.32.0</version><!-- {x-version-update:google-http-client-test:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-xml</artifactId>
-        <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-xml:current} -->
+        <version>1.32.0</version><!-- {x-version-update:google-http-client-xml:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-http-client-findbugs/pom.xml
+++ b/google-http-client-findbugs/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-findbugs</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-findbugs:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-findbugs:current} -->
   <name>Google APIs Client Library Findbugs custom plugin.</name>
 
   <build>

--- a/google-http-client-gson/pom.xml
+++ b/google-http-client-gson/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-gson</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-gson:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-gson:current} -->
   <name>GSON extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-jackson2/pom.xml
+++ b/google-http-client-jackson2/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-jackson2</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-jackson2:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-jackson2:current} -->
   <name>Jackson 2 extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-protobuf/pom.xml
+++ b/google-http-client-protobuf/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-protobuf</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-protobuf:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-protobuf:current} -->
   <name>Protocol Buffer extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-test/pom.xml
+++ b/google-http-client-test/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-test</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-test:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-test:current} -->
   <name>Shared classes used for testing of artifacts in the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client-xml/pom.xml
+++ b/google-http-client-xml/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client-xml</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-xml:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-xml:current} -->
   <name>XML extensions to the Google HTTP Client Library for Java.</name>
 
   <build>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-http-client</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client:current} -->
   <name>Google HTTP Client Library for Java</name>
   <description>
     Google HTTP Client Library for Java. Functionality that works on all supported Java platforms,

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-parent</artifactId>
-  <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+  <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google HTTP Client Library for Java</name>
 
@@ -540,7 +540,7 @@
       - google-api-java-client/google-api-client-assembly/android-properties (make the filenames match the version here)
       - Internally, update the default features.json file
     -->
-    <project.http-client.version>1.31.1-SNAPSHOT</project.http-client.version><!-- {x-version-update:google-http-client-parent:current} -->
+    <project.http-client.version>1.32.0</project.http-client.version><!-- {x-version-update:google-http-client-parent:current} -->
     <project.appengine.version>1.9.71</project.appengine.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.jsr305.version>3.0.2</project.jsr305.version>

--- a/samples/dailymotion-simple-cmdline-sample/pom.xml
+++ b/samples/dailymotion-simple-cmdline-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.http-client</groupId>
     <artifactId>google-http-client-parent</artifactId>
-    <version>1.31.1-SNAPSHOT</version><!-- {x-version-update:google-http-client-parent:current} -->
+    <version>1.32.0</version><!-- {x-version-update:google-http-client-parent:current} -->
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>dailymotion-simple-cmdline-sample</artifactId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,17 +1,17 @@
 # Format:
 # module:released-version:current-version
 
-google-http-client:1.31.0:1.31.1-SNAPSHOT
-google-http-client-bom:1.31.0:1.31.1-SNAPSHOT
-google-http-client-parent:1.31.0:1.31.1-SNAPSHOT
-google-http-client-android:1.31.0:1.31.1-SNAPSHOT
-google-http-client-android-test:1.31.0:1.31.1-SNAPSHOT
-google-http-client-apache-v2:1.31.0:1.31.1-SNAPSHOT
-google-http-client-appengine:1.31.0:1.31.1-SNAPSHOT
-google-http-client-assembly:1.31.0:1.31.1-SNAPSHOT
-google-http-client-findbugs:1.31.0:1.31.1-SNAPSHOT
-google-http-client-gson:1.31.0:1.31.1-SNAPSHOT
-google-http-client-jackson2:1.31.0:1.31.1-SNAPSHOT
-google-http-client-protobuf:1.31.0:1.31.1-SNAPSHOT
-google-http-client-test:1.31.0:1.31.1-SNAPSHOT
-google-http-client-xml:1.31.0:1.31.1-SNAPSHOT
+google-http-client:1.32.0:1.32.0
+google-http-client-bom:1.32.0:1.32.0
+google-http-client-parent:1.32.0:1.32.0
+google-http-client-android:1.32.0:1.32.0
+google-http-client-android-test:1.32.0:1.32.0
+google-http-client-apache-v2:1.32.0:1.32.0
+google-http-client-appengine:1.32.0:1.32.0
+google-http-client-assembly:1.32.0:1.32.0
+google-http-client-findbugs:1.32.0:1.32.0
+google-http-client-gson:1.32.0:1.32.0
+google-http-client-jackson2:1.32.0:1.32.0
+google-http-client-protobuf:1.32.0:1.32.0
+google-http-client-test:1.32.0:1.32.0
+google-http-client-xml:1.32.0:1.32.0


### PR DESCRIPTION
This pull request was generated using releasetool.

09-11-2019 10:34 PDT

### Implementation Changes
- fix: grab version from the package metadata ([#806](https://github.com/google/google-http-java-client/pull/806))
- fix: correct connect timeout setting for ApacheHttpRequest ([#803](https://github.com/google/google-http-java-client/pull/803))
- fix: disable uri normalization in ApacheHttpRequest ([#804](https://github.com/google/google-http-java-client/pull/804))
- fix: OpenCensus spans should close on IOExceptions ([#797](https://github.com/google/google-http-java-client/pull/797))
- remove deprecated methods ([#769](https://github.com/google/google-http-java-client/pull/769))
- stop exposing internal private state in JsonWebSignature ([#767](https://github.com/google/google-http-java-client/pull/767))

### Dependencies
- chore(deps): update opencensus packages to v0.24.0 ([#801](https://github.com/google/google-http-java-client/pull/801))
- Update to protobuf 3.9.1 ([#766](https://github.com/google/google-http-java-client/pull/766))
- Update guava to 28.0-android ([#760](https://github.com/google/google-http-java-client/pull/760))
- deps: Update OpenCensus packages to v0.23.0 ([#789](https://github.com/google/google-http-java-client/pull/789))

### Documentation
- docs: migrate docs into source control from the wiki ([#807](https://github.com/google/google-http-java-client/pull/807))
- Point README developer guide and setup instructions to the GitHub wiki ([#765](https://github.com/google/google-http-java-client/pull/765))
- Update JWT documentation URLs ([#759](https://github.com/google/google-http-java-client/pull/759))

### Internal / Testing Changes
- build: regenerate common files from templates ([#813](https://github.com/google/google-http-java-client/pull/813))
- build: fix snapshot script to be executable ([#810](https://github.com/google/google-http-java-client/pull/810))
- chore: regenerate common templates ([#802](https://github.com/google/google-http-java-client/pull/802))
- chore: regenerate common configuration from templates
- chore: regenerate common configuration from templates
- build: fix missing version warnings ([#792](https://github.com/google/google-http-java-client/pull/792))
- Regenerate common configuration files from our templates
- Import google_checks.xml for maven-checkstyle-plugin ([#786](https://github.com/google/google-http-java-client/pull/786))
- remove obsolete and deprecated parent ([#785](https://github.com/google/google-http-java-client/pull/785))
- Remove deprecated testing method ([#777](https://github.com/google/google-http-java-client/pull/777))
- add module name to submodules ([#783](https://github.com/google/google-http-java-client/pull/783))
- remove maven jarjar plugin ([#773](https://github.com/google/google-http-java-client/pull/773))
- Remove google-http-client-jdo from versions.txt manifest ([#775](https://github.com/google/google-http-java-client/pull/775))
- Cleanup: remove deprecated code, fix warnings, and use JUnit 4 ([#763](https://github.com/google/google-http-java-client/pull/763))
- Update common repo files from synthtool ([#756](https://github.com/google/google-http-java-client/pull/756))
- Bump next snapshot ([#755](https://github.com/google/google-http-java-client/pull/755))