### PR TITLE
feat: wrap GZIPInputStream for connection reuse

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/ConsumingInputStream.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/ConsumingInputStream.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.client.http;
+
+import com.google.api.client.util.Preconditions;
+import com.google.common.io.ByteStreams;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This class in meant to wrap an {@link InputStream} so that all bytes in the steam are read and
+ * discarded on {@link InputStream#close()}. This ensures that the underlying connection has the
+ * option to be reused.
+ */
+final class ConsumingInputStream extends InputStream {
+  private InputStream inputStream;
+  private boolean closed = false;
+
+  ConsumingInputStream(InputStream inputStream) {
+    this.inputStream = Preconditions.checkNotNull(inputStream);
+  }
+
+  @Override
+  public int read() throws IOException {
+    return inputStream.read();
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    return inputStream.read(b, off, len);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!closed && inputStream != null) {
+      try {
+        ByteStreams.exhaust(this);
+        inputStream.close();
+      } finally {
+        this.closed = true;
+      }
+    }
+  }
+}

--- a/google-http-client/src/main/java/com/google/api/client/http/ConsumingInputStream.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/ConsumingInputStream.java
@@ -16,8 +16,8 @@
 
 package com.google.api.client.http;
 
-import com.google.api.client.util.Preconditions;
 import com.google.common.io.ByteStreams;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -26,30 +26,19 @@ import java.io.InputStream;
  * discarded on {@link InputStream#close()}. This ensures that the underlying connection has the
  * option to be reused.
  */
-final class ConsumingInputStream extends InputStream {
-  private InputStream inputStream;
+final class ConsumingInputStream extends FilterInputStream {
   private boolean closed = false;
 
   ConsumingInputStream(InputStream inputStream) {
-    this.inputStream = Preconditions.checkNotNull(inputStream);
-  }
-
-  @Override
-  public int read() throws IOException {
-    return inputStream.read();
-  }
-
-  @Override
-  public int read(byte[] b, int off, int len) throws IOException {
-    return inputStream.read(b, off, len);
+    super(inputStream);
   }
 
   @Override
   public void close() throws IOException {
-    if (!closed && inputStream != null) {
+    if (!closed && in != null) {
       try {
         ByteStreams.exhaust(this);
-        inputStream.close();
+        super.in.close();
       } finally {
         this.closed = true;
       }

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -331,8 +331,8 @@ public final class HttpResponse {
           if (!returnRawInputStream
               && contentEncoding != null
               && contentEncoding.contains("gzip")) {
-            lowLevelResponseContent = new ConsumingInputStream(
-                new GZIPInputStream(lowLevelResponseContent));
+            lowLevelResponseContent =
+                new ConsumingInputStream(new GZIPInputStream(lowLevelResponseContent));
           }
           // logging (wrap content with LoggingInputStream)
           Logger logger = HttpTransport.LOGGER;
@@ -355,44 +355,6 @@ public final class HttpResponse {
       contentRead = true;
     }
     return content;
-  }
-
-  static class ConsumingInputStream extends InputStream {
-    private InputStream inputStream;
-    private boolean closed = false;
-
-    private ConsumingInputStream(InputStream inputStream) {
-      this.inputStream = Preconditions.checkNotNull(inputStream);
-    }
-
-    @Override
-    public int read() throws IOException {
-      return inputStream.read();
-    }
-
-    @Override
-    public int read(byte[] b, int off, int len) throws IOException {
-      return inputStream.read(b, off, len);
-    }
-
-    @Override
-    public void close() throws IOException {
-      if (!closed && inputStream != null) {
-        try {
-          drainInputStream(this);
-          inputStream.close();
-        } finally {
-          this.closed = true;
-        }
-      }
-    }
-
-    static void drainInputStream(final InputStream inputStream) throws IOException {
-      byte buffer[] = new byte[1024];
-      while (inputStream.read(buffer) >= 0) {
-        // do nothing
-      }
-    }
   }
 
   /**

--- a/google-http-client/src/test/java/com/google/api/client/http/ConsumingInputStreamTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/ConsumingInputStreamTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.client.http;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+
+public class ConsumingInputStreamTest {
+
+  @Test
+  public void testClose_drainsBytesOnClose() throws IOException {
+    MockInputStream mockInputStream = new MockInputStream("abc123".getBytes());
+    InputStream consumingInputStream = new ConsumingInputStream(mockInputStream);
+
+    assertEquals(6, mockInputStream.getBytesToRead());
+
+    // read one byte
+    consumingInputStream.read();
+    assertEquals(5, mockInputStream.getBytesToRead());
+
+    // closing the stream should read the remaining bytes
+    consumingInputStream.close();
+    assertEquals(0, mockInputStream.getBytesToRead());
+  }
+
+  private class MockInputStream extends InputStream {
+    private int bytesToRead;
+
+    MockInputStream(byte[] data) {
+      this.bytesToRead = data.length;
+    }
+
+    @Override
+    public int read() throws IOException {
+      if (bytesToRead == 0) {
+        return -1;
+      }
+      bytesToRead--;
+      return 1;
+    }
+
+    int getBytesToRead() {
+      return bytesToRead;
+    }
+  }
+}

--- a/google-http-client/src/test/java/com/google/api/client/http/ConsumingInputStreamTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/ConsumingInputStreamTest.java
@@ -20,13 +20,15 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 
 public class ConsumingInputStreamTest {
 
   @Test
   public void testClose_drainsBytesOnClose() throws IOException {
-    MockInputStream mockInputStream = new MockInputStream("abc123".getBytes());
+    MockInputStream mockInputStream = new MockInputStream("abc123".getBytes(StandardCharsets.UTF_8));
     InputStream consumingInputStream = new ConsumingInputStream(mockInputStream);
 
     assertEquals(6, mockInputStream.getBytesToRead());

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
@@ -26,11 +26,14 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 import junit.framework.TestCase;
+import sun.net.www.http.ChunkedInputStream;
 
 /**
  * Tests {@link HttpResponse}.
@@ -456,5 +459,41 @@ public class HttpResponseTest extends TestCase {
     assertFalse(
         "it should not decompress stream",
         request.execute().getContent() instanceof GZIPInputStream);
+  }
+
+  public void testGetContent_gzipEncoding_finishReading() throws IOException {
+    byte[] dataToCompress = "abcd".getBytes(StandardCharsets.UTF_8);
+    byte[] mockBytes;
+    try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream(dataToCompress.length)) {
+      GZIPOutputStream zipStream = new GZIPOutputStream((byteStream));
+      zipStream.write(dataToCompress);
+      zipStream.close();
+      mockBytes = byteStream.toByteArray();
+    }
+    final MockLowLevelHttpResponse mockResponse = new MockLowLevelHttpResponse();
+    mockResponse.setContent(mockBytes);
+    mockResponse.setContentEncoding("gzip");
+    mockResponse.setContentType("text/plain");
+
+    HttpTransport transport =
+        new MockHttpTransport() {
+          @Override
+          public LowLevelHttpRequest buildRequest(String method, final String url)
+              throws IOException {
+            return new MockLowLevelHttpRequest() {
+              @Override
+              public LowLevelHttpResponse execute() throws IOException {
+                return mockResponse;
+              }
+            };
+          }
+        };
+    HttpRequest request =
+        transport.createRequestFactory().buildHeadRequest(HttpTesting.SIMPLE_GENERIC_URL);
+    HttpResponse response = request.execute();
+    TestableByteArrayInputStream output = (TestableByteArrayInputStream) mockResponse.getContent();
+    assertFalse(output.isClosed());
+    assertEquals("abcd", response.parseAsString());
+    assertTrue(output.isClosed());
   }
 }

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
@@ -33,7 +33,6 @@ import java.util.logging.Level;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import junit.framework.TestCase;
-import sun.net.www.http.ChunkedInputStream;
 
 /**
  * Tests {@link HttpResponse}.


### PR DESCRIPTION
If a connection is closed and there are some bytes that have not
been read that connection can't be reused. Now GZIPInputStream
will have all of its bytes read on close automatically to promote
connection reuse.

Cherry-picked: #749
Fixes: #367