### PR TITLE
fix: HttpResponse GZip content encoding equality change

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -80,6 +80,12 @@ public final class HttpResponse {
   /** Whether {@link #getContent()} should return raw input stream. */
   private final boolean returnRawInputStream;
 
+  /** Content encoding for GZip */
+  private static final String CONTENT_ENCODING_GZIP = "gzip";
+
+  /** Content encoding for GZip HTTP 1.1 */
+  private static final String CONTENT_ENCODING_XGZIP = "x-gzip";
+
   /**
    * Determines the limit to the content size that will be logged during {@link #getContent()}.
    *
@@ -330,7 +336,8 @@ public final class HttpResponse {
           String contentEncoding = this.contentEncoding;
           if (!returnRawInputStream
               && contentEncoding != null
-              && contentEncoding.contains("gzip")) {
+              && (CONTENT_ENCODING_GZIP.equalsIgnoreCase(contentEncoding.trim())
+                  || CONTENT_ENCODING_XGZIP.equalsIgnoreCase(contentEncoding.trim()))) {
             lowLevelResponseContent = new GZIPInputStream(lowLevelResponseContent);
           }
           // logging (wrap content with LoggingInputStream)

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -335,8 +335,8 @@ public final class HttpResponse {
         try {
           // gzip encoding (wrap content with GZipInputStream)
           if (!returnRawInputStream && this.contentEncoding != null) {
-            final String oontentEncoding = this.contentEncoding.trim().toLowerCase(Locale.ENGLISH);
-            if (CONTENT_ENCODING_GZIP.equals(oontentEncoding) || CONTENT_ENCODING_XGZIP.equals(oontentEncoding)) {
+            String oontentencoding = this.contentEncoding.trim().toLowerCase(Locale.ENGLISH);
+            if (CONTENT_ENCODING_GZIP.equals(oontentencoding) || CONTENT_ENCODING_XGZIP.equals(oontentencoding)) {
               lowLevelResponseContent =
                   new ConsumingInputStream(new GZIPInputStream(lowLevelResponseContent));
             }

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
@@ -333,12 +334,12 @@ public final class HttpResponse {
         boolean contentProcessed = false;
         try {
           // gzip encoding (wrap content with GZipInputStream)
-          if (!returnRawInputStream
-              && this.contentEncoding != null
-              && (CONTENT_ENCODING_GZIP.equals(this.contentEncoding.trim())
-              || CONTENT_ENCODING_XGZIP.equals(this.contentEncoding.trim()))) {
-            lowLevelResponseContent =
-                new ConsumingInputStream(new GZIPInputStream(lowLevelResponseContent));
+          if (!returnRawInputStream && this.contentEncoding != null) {
+            final String oontentEncoding = this.contentEncoding.trim().toLowerCase(Locale.ENGLISH);
+            if (CONTENT_ENCODING_GZIP.equals(oontentEncoding) || CONTENT_ENCODING_XGZIP.equals(oontentEncoding)) {
+              lowLevelResponseContent =
+                  new ConsumingInputStream(new GZIPInputStream(lowLevelResponseContent));
+            }
           }
           // logging (wrap content with LoggingInputStream)
           Logger logger = HttpTransport.LOGGER;

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -83,7 +83,7 @@ public final class HttpResponse {
   /** Content encoding for GZip */
   private static final String CONTENT_ENCODING_GZIP = "gzip";
 
-  /** Content encoding for GZip HTTP 1.1 */
+  /** Content encoding for GZip (legacy) */
   private static final String CONTENT_ENCODING_XGZIP = "x-gzip";
 
   /**
@@ -333,13 +333,12 @@ public final class HttpResponse {
         boolean contentProcessed = false;
         try {
           // gzip encoding (wrap content with GZipInputStream)
-          String contentEncoding = this.contentEncoding;
           if (!returnRawInputStream
-              && contentEncoding != null
-                  && (CONTENT_ENCODING_GZIP.equalsIgnoreCase(contentEncoding.trim())
-                      || CONTENT_ENCODING_XGZIP.equalsIgnoreCase(contentEncoding.trim()))) {
+                  && this.contentEncoding != null
+                  && (CONTENT_ENCODING_GZIP.equalsIgnoreCase(this.contentEncoding.trim())
+                      || CONTENT_ENCODING_XGZIP.equalsIgnoreCase(this.contentEncoding.trim()))) {
             lowLevelResponseContent =
-                new ConsumingInputStream(new GZIPInputStream(lowLevelResponseContent));
+                    new ConsumingInputStream(new GZIPInputStream(lowLevelResponseContent));
           }
           // logging (wrap content with LoggingInputStream)
           Logger logger = HttpTransport.LOGGER;

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -334,11 +334,11 @@ public final class HttpResponse {
         try {
           // gzip encoding (wrap content with GZipInputStream)
           if (!returnRawInputStream
-                  && this.contentEncoding != null
-                  && (CONTENT_ENCODING_GZIP.equalsIgnoreCase(this.contentEncoding.trim())
-                      || CONTENT_ENCODING_XGZIP.equalsIgnoreCase(this.contentEncoding.trim()))) {
+              && this.contentEncoding != null
+              && (CONTENT_ENCODING_GZIP.equals(this.contentEncoding.trim())
+              || CONTENT_ENCODING_XGZIP.equals(this.contentEncoding.trim()))) {
             lowLevelResponseContent =
-                    new ConsumingInputStream(new GZIPInputStream(lowLevelResponseContent));
+                new ConsumingInputStream(new GZIPInputStream(lowLevelResponseContent));
           }
           // logging (wrap content with LoggingInputStream)
           Logger logger = HttpTransport.LOGGER;

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -461,6 +462,21 @@ public class HttpResponseTest extends TestCase {
   }
 
   public void testGetContent_gzipEncoding_finishReading() throws IOException {
+    do_testGetContent_gzipEncoding_finishReading("gzip");
+  }
+
+  public void testGetContent_gzipEncoding_finishReadingWithUppercaseContentEncoding() throws IOException {
+    do_testGetContent_gzipEncoding_finishReading("GZIP");
+  }
+
+  public void testGetContent_gzipEncoding_finishReadingWithDifferentDefaultLocaleAndUppercaseContentEncoding() throws IOException {
+    Locale originalDefaultLocale = Locale.getDefault();
+    Locale.setDefault(Locale.JAPAN);
+    do_testGetContent_gzipEncoding_finishReading("GZIP");
+    Locale.setDefault(originalDefaultLocale);
+  }
+
+  private void do_testGetContent_gzipEncoding_finishReading(String contentEncoding) throws IOException {
     byte[] dataToCompress = "abcd".getBytes(StandardCharsets.UTF_8);
     byte[] mockBytes;
     try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream(dataToCompress.length)) {
@@ -471,7 +487,7 @@ public class HttpResponseTest extends TestCase {
     }
     final MockLowLevelHttpResponse mockResponse = new MockLowLevelHttpResponse();
     mockResponse.setContent(mockBytes);
-    mockResponse.setContentEncoding("gzip");
+    mockResponse.setContentEncoding(contentEncoding);
     mockResponse.setContentType("text/plain");
 
     HttpTransport transport =

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
@@ -495,4 +495,30 @@ public class HttpResponseTest extends TestCase {
     assertEquals("abcd", response.parseAsString());
     assertTrue(output.isClosed());
   }
+
+  public void testGetContent_otherEncodingWithgzipInItsName_GzipIsNotUsed() throws IOException {
+    final MockLowLevelHttpResponse mockResponse = new MockLowLevelHttpResponse();
+    mockResponse.setContent("abcd");
+    mockResponse.setContentEncoding("otherEncodingWithgzipInItsName");
+    mockResponse.setContentType("text/plain");
+
+    HttpTransport transport =
+            new MockHttpTransport() {
+              @Override
+              public LowLevelHttpRequest buildRequest(String method, final String url)
+                      throws IOException {
+                return new MockLowLevelHttpRequest() {
+                  @Override
+                  public LowLevelHttpResponse execute() throws IOException {
+                    return mockResponse;
+                  }
+                };
+              }
+            };
+    HttpRequest request =
+            transport.createRequestFactory().buildHeadRequest(HttpTesting.SIMPLE_GENERIC_URL);
+    // If gzip was used on this response, an exception would be thrown
+    HttpResponse response = request.execute();
+    assertEquals("abcd", response.parseAsString());
+  }
 }

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
@@ -471,16 +471,21 @@ public class HttpResponseTest extends TestCase {
 
   public void testGetContent_gzipEncoding_finishReadingWithDifferentDefaultLocaleAndUppercaseContentEncoding() throws IOException {
     Locale originalDefaultLocale = Locale.getDefault();
-    Locale.setDefault(Locale.JAPAN);
-    do_testGetContent_gzipEncoding_finishReading("GZIP");
-    Locale.setDefault(originalDefaultLocale);
+    try {
+      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+      do_testGetContent_gzipEncoding_finishReading("GZIP");
+    } finally {
+      Locale.setDefault(originalDefaultLocale);
+    }
   }
 
   private void do_testGetContent_gzipEncoding_finishReading(String contentEncoding) throws IOException {
     byte[] dataToCompress = "abcd".getBytes(StandardCharsets.UTF_8);
     byte[] mockBytes;
-    try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream(dataToCompress.length)) {
-      GZIPOutputStream zipStream = new GZIPOutputStream((byteStream));
+    try (
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream(dataToCompress.length);
+        GZIPOutputStream zipStream = new GZIPOutputStream((byteStream))
+    ) {
       zipStream.write(dataToCompress);
       zipStream.close();
       mockBytes = byteStream.toByteArray();
@@ -506,10 +511,11 @@ public class HttpResponseTest extends TestCase {
     HttpRequest request =
         transport.createRequestFactory().buildHeadRequest(HttpTesting.SIMPLE_GENERIC_URL);
     HttpResponse response = request.execute();
-    TestableByteArrayInputStream output = (TestableByteArrayInputStream) mockResponse.getContent();
-    assertFalse(output.isClosed());
-    assertEquals("abcd", response.parseAsString());
-    assertTrue(output.isClosed());
+    try (TestableByteArrayInputStream output = (TestableByteArrayInputStream) mockResponse.getContent()) {
+      assertFalse(output.isClosed());
+      assertEquals("abcd", response.parseAsString());
+      assertTrue(output.isClosed());
+    }
   }
 
   public void testGetContent_otherEncodingWithgzipInItsName_GzipIsNotUsed() throws IOException {

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
@@ -503,20 +503,19 @@ public class HttpResponseTest extends TestCase {
     mockResponse.setContentType("text/plain");
 
     HttpTransport transport =
-            new MockHttpTransport() {
+        new MockHttpTransport() {
+          @Override
+          public LowLevelHttpRequest buildRequest(String method, final String url)
+              throws IOException {
+            return new MockLowLevelHttpRequest() {
               @Override
-              public LowLevelHttpRequest buildRequest(String method, final String url)
-                      throws IOException {
-                return new MockLowLevelHttpRequest() {
-                  @Override
-                  public LowLevelHttpResponse execute() throws IOException {
-                    return mockResponse;
-                  }
-                };
+              public LowLevelHttpResponse execute() throws IOException {
+                return mockResponse;
               }
             };
-    HttpRequest request =
-            transport.createRequestFactory().buildHeadRequest(HttpTesting.SIMPLE_GENERIC_URL);
+          }
+        };
+    HttpRequest request = transport.createRequestFactory().buildHeadRequest(HttpTesting.SIMPLE_GENERIC_URL);
     // If gzip was used on this response, an exception would be thrown
     HttpResponse response = request.execute();
     assertEquals("abcd", response.parseAsString());


### PR DESCRIPTION
Fixes #842 by having HttpResponse compare (case insensitive) the content-encoding against "gzip" and "x-gzip" (HTTP 1.1).