### PR TITLE
fix: make opencensus an optional dependency

### DIFF
--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -124,10 +124,12 @@
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-api</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-contrib-http-util</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -153,6 +155,11 @@
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-impl-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -159,11 +159,6 @@
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
-      <artifactId>opencensus-impl-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.opencensus</groupId>
       <artifactId>opencensus-testing</artifactId>
       <scope>test</scope>
     </dependency>

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -853,7 +853,7 @@ public final class HttpRequest {
       }
       // build low-level HTTP request
       String urlString = url.build();
-      span.addCommonHTTPAttributes(requestMethod, url.getHost(), url.getRawPath(), urlString);
+      span.addCommonHttpAttributes(requestMethod, url.getHost(), url.getRawPath(), urlString);
 
       LowLevelHttpRequest lowLevelHttpRequest = transport.buildRequest(requestMethod, urlString);
       Logger logger = HttpTransport.LOGGER;

--- a/google-http-client/src/main/java/com/google/api/client/http/OpenCensusScope.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/OpenCensusScope.java
@@ -1,24 +1,19 @@
 /**
  * Copyright 2019 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.api.client.http;
 
-/**
- * A thin wrapper around an OpenCensus Scope with some convenience methods.
- */
+/** A thin wrapper around an OpenCensus Scope with some convenience methods. */
 final class OpenCensusScope implements Scope {
   private final io.opencensus.common.Scope scope;
 

--- a/google-http-client/src/main/java/com/google/api/client/http/OpenCensusScope.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/OpenCensusScope.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2019 Google LLC
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
  *
- * <p>https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * Unless required by applicable law or agreed to in writing, software distributed under the
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.

--- a/google-http-client/src/main/java/com/google/api/client/http/OpenCensusScope.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/OpenCensusScope.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.client.http;
+
+/**
+ * A thin wrapper around an OpenCensus Scope with some convenience methods.
+ */
+final class OpenCensusScope implements Scope {
+  private final io.opencensus.common.Scope scope;
+
+  OpenCensusScope(OpenCensusSpan openCensusSpan) {
+    this.scope = OpenCensusUtils.getTracer().withSpan(openCensusSpan.getSpan());
+  }
+
+  @Override
+  public final void close() {
+    scope.close();
+  }
+}

--- a/google-http-client/src/main/java/com/google/api/client/http/OpenCensusSpan.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/OpenCensusSpan.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.client.http;
+
+import io.opencensus.contrib.http.util.HttpTraceAttributeConstants;
+import io.opencensus.trace.AttributeValue;
+import javax.annotation.Nullable;
+
+/**
+ * A thin wrapper around an OpenCensus Span with some convenience methods.
+ */
+final class OpenCensusSpan implements Span {
+  private final io.opencensus.trace.Span span;
+
+  OpenCensusSpan() {
+    this.span = OpenCensusUtils.getTracer()
+        .spanBuilder(OpenCensusUtils.SPAN_NAME_HTTP_REQUEST_EXECUTE)
+        .setRecordEvents(OpenCensusUtils.isRecordEvent())
+        .startSpan();
+  }
+
+  @Override
+  public final void addCommonHTTPAttributes(String requestMethod, String host, String path, String url) {
+    addSpanAttribute(HttpTraceAttributeConstants.HTTP_METHOD, requestMethod);
+    addSpanAttribute(HttpTraceAttributeConstants.HTTP_HOST, host);
+    addSpanAttribute(HttpTraceAttributeConstants.HTTP_PATH, path);
+    addSpanAttribute(HttpTraceAttributeConstants.HTTP_URL, url);
+  }
+
+  @Override
+  public final void addUserAgent(String value) {
+    addSpanAttribute(HttpTraceAttributeConstants.HTTP_USER_AGENT, value);
+  }
+
+  @Override
+  public final void addAnnotation(String description) {
+    span.addAnnotation(description);
+  }
+
+  @Override
+  public final void addHeaders(HttpHeaders headers) {
+    OpenCensusUtils.propagateTracingContext(span, headers);
+  }
+
+  @Override
+  public final void end(@Nullable Integer statusCode) {
+    span.end(OpenCensusUtils.getEndSpanOptions(statusCode));
+  }
+
+  @Override
+  public final void recordSentMessageEvent(long contentLength) {
+    OpenCensusUtils.recordSentMessageEvent(span, contentLength);
+  }
+
+  @Override
+  public final void recordReceivedMessageEvent(long contentLength) {
+    OpenCensusUtils.recordReceivedMessageEvent(span, contentLength);
+  }
+
+  io.opencensus.trace.Span getSpan() {
+    return this.span;
+  }
+
+  private void addSpanAttribute(String key, String value) {
+    if (value != null) {
+      span.putAttribute(key, AttributeValue.stringAttributeValue(value));
+    }
+  }
+}

--- a/google-http-client/src/main/java/com/google/api/client/http/OpenCensusSpan.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/OpenCensusSpan.java
@@ -1,40 +1,37 @@
 /**
  * Copyright 2019 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.api.client.http;
 
 import io.opencensus.contrib.http.util.HttpTraceAttributeConstants;
 import io.opencensus.trace.AttributeValue;
 import javax.annotation.Nullable;
 
-/**
- * A thin wrapper around an OpenCensus Span with some convenience methods.
- */
+/** A thin wrapper around an OpenCensus Span with some convenience methods. */
 final class OpenCensusSpan implements Span {
   private final io.opencensus.trace.Span span;
 
   OpenCensusSpan() {
-    this.span = OpenCensusUtils.getTracer()
-        .spanBuilder(OpenCensusUtils.SPAN_NAME_HTTP_REQUEST_EXECUTE)
-        .setRecordEvents(OpenCensusUtils.isRecordEvent())
-        .startSpan();
+    this.span =
+        OpenCensusUtils.getTracer()
+            .spanBuilder(OpenCensusUtils.SPAN_NAME_HTTP_REQUEST_EXECUTE)
+            .setRecordEvents(OpenCensusUtils.isRecordEvent())
+            .startSpan();
   }
 
   @Override
-  public final void addCommonHTTPAttributes(String requestMethod, String host, String path, String url) {
+  public final void addCommonHttpAttributes(
+      String requestMethod, String host, String path, String url) {
     addSpanAttribute(HttpTraceAttributeConstants.HTTP_METHOD, requestMethod);
     addSpanAttribute(HttpTraceAttributeConstants.HTTP_HOST, host);
     addSpanAttribute(HttpTraceAttributeConstants.HTTP_PATH, path);

--- a/google-http-client/src/main/java/com/google/api/client/http/OpenCensusSpan.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/OpenCensusSpan.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2019 Google LLC
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
  *
- * <p>https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * Unless required by applicable law or agreed to in writing, software distributed under the
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.

--- a/google-http-client/src/main/java/com/google/api/client/http/OpenCensusUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/OpenCensusUtils.java
@@ -14,7 +14,6 @@
 
 package com.google.api.client.http;
 
-import com.google.api.client.util.Beta;
 import com.google.api.client.util.Preconditions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -34,14 +33,12 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * {@link Beta} <br>
  * Utilities for Census monitoring and tracing.
  *
  * @author Hailong Wen
  * @since 1.28
  */
-@Beta
-public class OpenCensusUtils {
+class OpenCensusUtils {
 
   private static final Logger logger = Logger.getLogger(OpenCensusUtils.class.getName());
 

--- a/google-http-client/src/main/java/com/google/api/client/http/Scope.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/Scope.java
@@ -1,27 +1,20 @@
 /**
  * Copyright 2019 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.api.client.http;
 
-/**
- * A wrapper for OpenCensus' Scope.
- */
+/** A wrapper for OpenCensus' Scope. */
 interface Scope {
-  /**
-   * Closes a {@link Scope}.
-   */
+  /** Closes a {@link Scope}. */
   void close();
 }

--- a/google-http-client/src/main/java/com/google/api/client/http/Scope.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/Scope.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.client.http;
+
+/**
+ * A wrapper for OpenCensus' Scope.
+ */
+interface Scope {
+  /**
+   * Closes a {@link Scope}.
+   */
+  void close();
+}

--- a/google-http-client/src/main/java/com/google/api/client/http/Scope.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/Scope.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2019 Google LLC
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
  *
- * <p>https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * Unless required by applicable law or agreed to in writing, software distributed under the
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.

--- a/google-http-client/src/main/java/com/google/api/client/http/ScopeFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/ScopeFactory.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.client.http;
+
+class ScopeFactory {
+  /** This is used to check if the optional OpenCensus deps are on the classpath */
+  private static final boolean HAS_OPEN_CENSUS_CLASSES_ON_CLASSPATH = hasClasses(
+          "io.opencensus.trace.Span",
+          "io.opencensus.implcore.trace.RecordEventsSpanImpl",
+          "io.opencensus.contrib.http.util.HttpPropagationUtil"
+  );
+
+  private static NoopScope noopScope = new NoopScope();
+
+  static Scope getScope(Span span) {
+    if (HAS_OPEN_CENSUS_CLASSES_ON_CLASSPATH) {
+      return new OpenCensusScope((OpenCensusSpan) span);
+    } else {
+      return noopScope;
+    }
+  }
+
+  private static boolean hasClasses(String ...classNames) {
+    for (String className : classNames) {
+      try {
+        Class.forName(className, false, ScopeFactory.class.getClassLoader());
+      } catch (Throwable t) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static class NoopScope implements Scope {
+    @Override
+    public void close() {}
+  }
+
+  private ScopeFactory() {}
+}

--- a/google-http-client/src/main/java/com/google/api/client/http/ScopeFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/ScopeFactory.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2019 Google LLC
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
  *
- * <p>https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * Unless required by applicable law or agreed to in writing, software distributed under the
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
@@ -18,7 +18,6 @@ class ScopeFactory {
   private static final boolean HAS_OPEN_CENSUS_CLASSES_ON_CLASSPATH =
       hasClasses(
           "io.opencensus.trace.Span",
-          "io.opencensus.implcore.trace.RecordEventsSpanImpl",
           "io.opencensus.contrib.http.util.HttpPropagationUtil");
 
   private static NoopScope noopScope = new NoopScope();

--- a/google-http-client/src/main/java/com/google/api/client/http/ScopeFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/ScopeFactory.java
@@ -1,28 +1,25 @@
 /**
  * Copyright 2019 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.api.client.http;
 
 class ScopeFactory {
   /** This is used to check if the optional OpenCensus deps are on the classpath */
-  private static final boolean HAS_OPEN_CENSUS_CLASSES_ON_CLASSPATH = hasClasses(
+  private static final boolean HAS_OPEN_CENSUS_CLASSES_ON_CLASSPATH =
+      hasClasses(
           "io.opencensus.trace.Span",
           "io.opencensus.implcore.trace.RecordEventsSpanImpl",
-          "io.opencensus.contrib.http.util.HttpPropagationUtil"
-  );
+          "io.opencensus.contrib.http.util.HttpPropagationUtil");
 
   private static NoopScope noopScope = new NoopScope();
 
@@ -34,11 +31,11 @@ class ScopeFactory {
     }
   }
 
-  private static boolean hasClasses(String ...classNames) {
+  private static boolean hasClasses(String... classNames) {
     for (String className : classNames) {
       try {
         Class.forName(className, false, ScopeFactory.class.getClassLoader());
-      } catch (Throwable t) {
+      } catch (ClassNotFoundException t) {
         return false;
       }
     }

--- a/google-http-client/src/main/java/com/google/api/client/http/Span.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/Span.java
@@ -1,41 +1,30 @@
 /**
  * Copyright 2019 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.api.client.http;
 
 import javax.annotation.Nullable;
 
-/**
- * A wrapper for OpenCensus' Span.
- */
+/** A wrapper for OpenCensus' Span. */
 interface Span {
 
-  /**
-   * Adds requestMethod, host, path, and url to the Span's attributes.
-   */
-  void addCommonHTTPAttributes(String requestMethod, String host, String path, String url);
+  /** Adds requestMethod, host, path, and url to the Span's attributes. */
+  void addCommonHttpAttributes(String requestMethod, String host, String path, String url);
 
-  /**
-   * Adds user agent to the Span's attributes.
-   */
+  /** Adds user agent to the Span's attributes. */
   void addUserAgent(String value);
 
-  /**
-   * Adds an annotation to the Span.
-   */
+  /** Adds an annotation to the Span. */
   void addAnnotation(String description);
 
   /**
@@ -44,9 +33,7 @@ interface Span {
    */
   void addHeaders(HttpHeaders headers);
 
-  /**
-   * Marks the end of a {@link Span}.
-   */
+  /** Marks the end of a {@link Span}. */
   void end(@Nullable Integer statusCode);
 
   /**
@@ -60,5 +47,4 @@ interface Span {
    * represents the message size in application layer, i.e., content-length.
    */
   void recordReceivedMessageEvent(long contentLength);
-
 }

--- a/google-http-client/src/main/java/com/google/api/client/http/Span.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/Span.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.client.http;
+
+import javax.annotation.Nullable;
+
+/**
+ * A wrapper for OpenCensus' Span.
+ */
+interface Span {
+
+  /**
+   * Adds requestMethod, host, path, and url to the Span's attributes.
+   */
+  void addCommonHTTPAttributes(String requestMethod, String host, String path, String url);
+
+  /**
+   * Adds user agent to the Span's attributes.
+   */
+  void addUserAgent(String value);
+
+  /**
+   * Adds an annotation to the Span.
+   */
+  void addAnnotation(String description);
+
+  /**
+   * Propagate information of current tracing context. This information will be injected into HTTP
+   * header.
+   */
+  void addHeaders(HttpHeaders headers);
+
+  /**
+   * Marks the end of a {@link Span}.
+   */
+  void end(@Nullable Integer statusCode);
+
+  /**
+   * Records a new message event which contains the size of the request content. Note that the size
+   * represents the message size in application layer, i.e., content-length.
+   */
+  void recordSentMessageEvent(long contentLength);
+
+  /**
+   * Records a new message event which contains the size of the response content. Note that the size
+   * represents the message size in application layer, i.e., content-length.
+   */
+  void recordReceivedMessageEvent(long contentLength);
+
+}

--- a/google-http-client/src/main/java/com/google/api/client/http/Span.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/Span.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2019 Google LLC
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
  *
- * <p>https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * Unless required by applicable law or agreed to in writing, software distributed under the
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.

--- a/google-http-client/src/main/java/com/google/api/client/http/SpanFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/SpanFactory.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.api.client.http;
+
+import javax.annotation.Nullable;
+
+class SpanFactory {
+  /** This is used to check if the optional OpenCensus deps are on the classpath */
+  private static final boolean HAS_OPEN_CENSUS_CLASSES_ON_CLASSPATH = hasClasses(
+          "io.opencensus.trace.Span",
+          "io.opencensus.implcore.trace.RecordEventsSpanImpl",
+          "io.opencensus.contrib.http.util.HttpPropagationUtil"
+  );
+
+  private static final NoopSpan noopSpan = new NoopSpan();
+
+  static Span getSpan() {
+    if (HAS_OPEN_CENSUS_CLASSES_ON_CLASSPATH) {
+      return new OpenCensusSpan();
+    } else {
+      return noopSpan;
+    }
+  }
+
+  private static boolean hasClasses(String ...classNames) {
+    for (String className : classNames) {
+      try {
+        Class.forName(className, false, ScopeFactory.class.getClassLoader());
+      } catch (Throwable t) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static class NoopSpan implements Span {
+    @Override
+    public void addCommonHTTPAttributes(String requestMethod, String host, String path, String url) {}
+
+    @Override
+    public void addUserAgent(String value) {}
+
+    @Override
+    public void addAnnotation(String description) {}
+
+    @Override
+    public void addHeaders(HttpHeaders headers) {}
+
+    @Override
+    public void end(@Nullable Integer statusCode) {}
+
+    @Override
+    public void recordSentMessageEvent(long contentLength) {}
+
+    @Override
+    public void recordReceivedMessageEvent(long contentLength) {}
+  }
+
+  private SpanFactory() {}
+}

--- a/google-http-client/src/main/java/com/google/api/client/http/SpanFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/SpanFactory.java
@@ -1,30 +1,27 @@
 /**
  * Copyright 2019 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.api.client.http;
 
 import javax.annotation.Nullable;
 
 class SpanFactory {
   /** This is used to check if the optional OpenCensus deps are on the classpath */
-  private static final boolean HAS_OPEN_CENSUS_CLASSES_ON_CLASSPATH = hasClasses(
+  private static final boolean HAS_OPEN_CENSUS_CLASSES_ON_CLASSPATH =
+      hasClasses(
           "io.opencensus.trace.Span",
           "io.opencensus.implcore.trace.RecordEventsSpanImpl",
-          "io.opencensus.contrib.http.util.HttpPropagationUtil"
-  );
+          "io.opencensus.contrib.http.util.HttpPropagationUtil");
 
   private static final NoopSpan noopSpan = new NoopSpan();
 
@@ -36,11 +33,11 @@ class SpanFactory {
     }
   }
 
-  private static boolean hasClasses(String ...classNames) {
+  private static boolean hasClasses(String... classNames) {
     for (String className : classNames) {
       try {
         Class.forName(className, false, ScopeFactory.class.getClassLoader());
-      } catch (Throwable t) {
+      } catch (ClassNotFoundException t) {
         return false;
       }
     }
@@ -49,7 +46,8 @@ class SpanFactory {
 
   private static class NoopSpan implements Span {
     @Override
-    public void addCommonHTTPAttributes(String requestMethod, String host, String path, String url) {}
+    public void addCommonHttpAttributes(
+        String requestMethod, String host, String path, String url) {}
 
     @Override
     public void addUserAgent(String value) {}

--- a/google-http-client/src/main/java/com/google/api/client/http/SpanFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/SpanFactory.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2019 Google LLC
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
  *
- * <p>https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * Unless required by applicable law or agreed to in writing, software distributed under the
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
@@ -20,7 +20,6 @@ class SpanFactory {
   private static final boolean HAS_OPEN_CENSUS_CLASSES_ON_CLASSPATH =
       hasClasses(
           "io.opencensus.trace.Span",
-          "io.opencensus.implcore.trace.RecordEventsSpanImpl",
           "io.opencensus.contrib.http.util.HttpPropagationUtil");
 
   private static final NoopSpan noopSpan = new NoopSpan();

--- a/google-http-client/src/test/java/com/google/api/client/http/OpenCensusUtilsTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/OpenCensusUtilsTest.java
@@ -14,7 +14,6 @@
 
 package com.google.api.client.http;
 
-
 import io.opencensus.trace.Annotation;
 import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.BlankSpan;

--- a/pom.xml
+++ b/pom.xml
@@ -245,21 +245,31 @@
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-api</artifactId>
         <version>${project.opencensus.version}</version>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-contrib-http-util</artifactId>
         <version>${project.opencensus.version}</version>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-impl</artifactId>
         <version>${project.opencensus.version}</version>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-testing</artifactId>
         <version>${project.opencensus.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.opencensus</groupId>
+        <artifactId>opencensus-impl-core</artifactId>
+        <version>${project.opencensus.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
With these changes the user has the option to use opencensus. If
the deps are not on the classpath noop impls will be used. In the
future opencensus will be ripped out in favor of opentelemetry.

As a part of these changes OpenCensusUtils was moved to a
package-private scope.

Fixes: #621