### PR TITLE
Fix various non-functional checkstyle warnings

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/GZipEncoding.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/GZipEncoding.java
@@ -43,6 +43,7 @@ public class GZipEncoding implements HttpEncoding {
             try {
               flush();
             } catch (IOException ignored) {
+                // Nothing else we can do here
             }
           }
         };

--- a/google-http-client/src/main/java/com/google/api/client/testing/util/TestableByteArrayInputStream.java
+++ b/google-http-client/src/main/java/com/google/api/client/testing/util/TestableByteArrayInputStream.java
@@ -41,7 +41,7 @@ public class TestableByteArrayInputStream extends ByteArrayInputStream {
    * @param offset offset in the buffer of the first byte to read
    * @param length maximum number of bytes to read from the buffer
    */
-  public TestableByteArrayInputStream(byte buf[], int offset, int length) {
+  public TestableByteArrayInputStream(byte[] buf, int offset, int length) {
     super(buf);
   }
 

--- a/google-http-client/src/main/java/com/google/api/client/util/ArrayValueMap.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/ArrayValueMap.java
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package com.google.api.client.util;
 
 import java.lang.reflect.Field;


### PR DESCRIPTION
Fixes the following checkstyle warnings:

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/util/ArrayValueMap.java:14: 'package' should be separated from previous statement. [EmptyLineSeparator]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/http/GZipEncoding.java:45: Empty catch block. [EmptyCatchBlock]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/testing/util/TestableByteArrayInputStream.java:44:47: Array brackets at illegal position. [ArrayTypeStyle]
