### PR TITLE
Fix various OverloadMethodsDeclarationOrder warnings

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/AbstractHttpContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/AbstractHttpContent.java
@@ -111,11 +111,6 @@ public abstract class AbstractHttpContent implements HttpContent {
     return computeLength(this);
   }
 
-  /** Default implementation returns {@code true}, but subclasses may override. */
-  public boolean retrySupported() {
-    return true;
-  }
-
   /**
    * Returns the computed content length based using {@link IOUtils#computeLength(StreamingContent)}
    * or instead {@code -1} if {@link HttpContent#retrySupported()} is {@code false} because the
@@ -130,5 +125,10 @@ public abstract class AbstractHttpContent implements HttpContent {
       return -1;
     }
     return IOUtils.computeLength(content);
+  }
+
+  /** Default implementation returns {@code true}, but subclasses may override. */
+  public boolean retrySupported() {
+    return true;
   }
 }

--- a/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
@@ -380,6 +380,22 @@ public class GenericUrl extends GenericData {
   }
 
   /**
+   * Returns the URI for the given encoded URL.
+   *
+   * <p>Any {@link URISyntaxException} is wrapped in an {@link IllegalArgumentException}.
+   *
+   * @param encodedUrl encoded URL
+   * @return URI
+   */
+  private static URI toURI(String encodedUrl) {
+    try {
+      return new URI(encodedUrl);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  /**
    * Constructs the URL based on the string representation of the URL from {@link #build()}.
    *
    * <p>Any {@link MalformedURLException} is wrapped in an {@link IllegalArgumentException}.
@@ -570,22 +586,6 @@ public class GenericUrl extends GenericData {
       buf.append('=').append(stringValue);
     }
     return first;
-  }
-
-  /**
-   * Returns the URI for the given encoded URL.
-   *
-   * <p>Any {@link URISyntaxException} is wrapped in an {@link IllegalArgumentException}.
-   *
-   * @param encodedUrl encoded URL
-   * @return URI
-   */
-  private static URI toURI(String encodedUrl) {
-    try {
-      return new URI(encodedUrl);
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException(e);
-    }
   }
 
   /**

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -429,6 +429,20 @@ public final class HttpResponse {
   }
 
   /**
+   * Parses the content of the HTTP response from {@link #getContent()} and reads it into a data
+   * type of key/value pairs using the parser returned by {@link HttpRequest#getParser()}.
+   *
+   * @return parsed data type instance or {@code null} for no content
+   * @since 1.10
+   */
+  public Object parseAs(Type dataType) throws IOException {
+    if (!hasMessageBody()) {
+      return null;
+    }
+    return request.getParser().parseAndClose(getContent(), getContentCharset(), dataType);
+  }
+
+  /**
    * Returns whether this response contains a message body as specified in {@href
    * http://tools.ietf.org/html/rfc2616#section-4.3}, calling {@link #ignore()} if {@code false}.
    */
@@ -442,20 +456,6 @@ public final class HttpResponse {
       return false;
     }
     return true;
-  }
-
-  /**
-   * Parses the content of the HTTP response from {@link #getContent()} and reads it into a data
-   * type of key/value pairs using the parser returned by {@link HttpRequest#getParser()}.
-   *
-   * @return parsed data type instance or {@code null} for no content
-   * @since 1.10
-   */
-  public Object parseAs(Type dataType) throws IOException {
-    if (!hasMessageBody()) {
-      return null;
-    }
-    return request.getParser().parseAndClose(getContent(), getContentCharset(), dataType);
   }
 
   /**

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpTransport.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpTransport.java
@@ -116,6 +116,17 @@ public abstract class HttpTransport {
   }
 
   /**
+   * Builds a low level HTTP request for the given HTTP method.
+   *
+   * @param method HTTP method
+   * @param url URL
+   * @return new low level HTTP request
+   * @throws IllegalArgumentException if HTTP method is not supported
+   * @since 1.12
+   */
+  protected abstract LowLevelHttpRequest buildRequest(String method, String url) throws IOException;
+
+  /**
    * Returns whether a specified HTTP method is supported by this transport.
    *
    * <p>Default implementation returns true if and only if the request method is {@code "DELETE"},
@@ -128,17 +139,6 @@ public abstract class HttpTransport {
   public boolean supportsMethod(String method) throws IOException {
     return Arrays.binarySearch(SUPPORTED_METHODS, method) >= 0;
   }
-
-  /**
-   * Builds a low level HTTP request for the given HTTP method.
-   *
-   * @param method HTTP method
-   * @param url URL
-   * @return new low level HTTP request
-   * @throws IllegalArgumentException if HTTP method is not supported
-   * @since 1.12
-   */
-  protected abstract LowLevelHttpRequest buildRequest(String method, String url) throws IOException;
 
   /**
    * Default implementation does nothing, but subclasses may override to possibly release allocated

--- a/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpResponse.java
@@ -94,6 +94,11 @@ final class ApacheHttpResponse extends LowLevelHttpResponse {
   }
 
   @Override
+  public String getHeaderValue(int index) {
+    return allHeaders[index].getValue();
+  }
+
+  @Override
   public int getHeaderCount() {
     return allHeaders.length;
   }
@@ -101,11 +106,6 @@ final class ApacheHttpResponse extends LowLevelHttpResponse {
   @Override
   public String getHeaderName(int index) {
     return allHeaders[index].getName();
-  }
-
-  @Override
-  public String getHeaderValue(int index) {
-    return allHeaders[index].getValue();
   }
 
   /**

--- a/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpTransport.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpTransport.java
@@ -151,18 +151,6 @@ public final class ApacheHttpTransport extends HttpTransport {
         SSLSocketFactory.getSocketFactory(), newDefaultHttpParams(), ProxySelector.getDefault());
   }
 
-  /** Returns a new instance of the default HTTP parameters we use. */
-  static HttpParams newDefaultHttpParams() {
-    HttpParams params = new BasicHttpParams();
-    // Turn off stale checking. Our connections break all the time anyway,
-    // and it's not worth it to pay the penalty of checking every time.
-    HttpConnectionParams.setStaleCheckingEnabled(params, false);
-    HttpConnectionParams.setSocketBufferSize(params, 8192);
-    ConnManagerParams.setMaxTotalConnections(params, 200);
-    ConnManagerParams.setMaxConnectionsPerRoute(params, new ConnPerRouteBean(20));
-    return params;
-  }
-
   /**
    * Creates a new instance of the Apache HTTP client that is used by the {@link
    * #ApacheHttpTransport()} constructor.
@@ -186,6 +174,18 @@ public final class ApacheHttpTransport extends HttpTransport {
       defaultHttpClient.setRoutePlanner(new ProxySelectorRoutePlanner(registry, proxySelector));
     }
     return defaultHttpClient;
+  }
+
+  /** Returns a new instance of the default HTTP parameters we use. */
+  static HttpParams newDefaultHttpParams() {
+    HttpParams params = new BasicHttpParams();
+    // Turn off stale checking. Our connections break all the time anyway,
+    // and it's not worth it to pay the penalty of checking every time.
+    HttpConnectionParams.setStaleCheckingEnabled(params, false);
+    HttpConnectionParams.setSocketBufferSize(params, 8192);
+    ConnManagerParams.setMaxTotalConnections(params, 200);
+    ConnManagerParams.setMaxConnectionsPerRoute(params, new ConnPerRouteBean(20));
+    return params;
   }
 
   @Override

--- a/google-http-client/src/main/java/com/google/api/client/json/JsonFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/JsonFactory.java
@@ -110,6 +110,18 @@ public abstract class JsonFactory {
   }
 
   /**
+   * Returns a serialized JSON string representation for the given item using {@link
+   * JsonGenerator#serialize(Object)}.
+   *
+   * @param item data key/value pairs
+   * @param pretty whether to return a pretty representation
+   * @return serialized JSON string representation
+   */
+  private String toString(Object item, boolean pretty) throws IOException {
+    return toByteStream(item, pretty).toString("UTF-8");
+  }
+
+  /**
    * Returns a pretty-printed serialized JSON string representation for the given item using {@link
    * JsonGenerator#serialize(Object)} with {@link JsonGenerator#enablePrettyPrint()}.
    *
@@ -135,18 +147,6 @@ public abstract class JsonFactory {
    */
   public final byte[] toByteArray(Object item) throws IOException {
     return toByteStream(item, false).toByteArray();
-  }
-
-  /**
-   * Returns a serialized JSON string representation for the given item using {@link
-   * JsonGenerator#serialize(Object)}.
-   *
-   * @param item data key/value pairs
-   * @param pretty whether to return a pretty representation
-   * @return serialized JSON string representation
-   */
-  private String toString(Object item, boolean pretty) throws IOException {
-    return toByteStream(item, pretty).toString("UTF-8");
   }
 
   /**

--- a/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
@@ -168,6 +168,41 @@ public abstract class JsonParser implements Closeable {
   }
 
   /**
+   * Parse a JSON Object from the given JSON parser -- which is closed after parsing completes --
+   * into the given destination object.
+   *
+   * <p>Before this method is called, the parser must either point to the start or end of a JSON
+   * object or to a field name.
+   *
+   * @param destination destination object
+   * @since 1.15
+   */
+  public final void parseAndClose(Object destination) throws IOException {
+    parseAndClose(destination, null);
+  }
+
+  /**
+   * {@link Beta} <br>
+   * Parse a JSON Object from the given JSON parser -- which is closed after parsing completes --
+   * into the given destination object, optionally using the given parser customizer.
+   *
+   * <p>Before this method is called, the parser must either point to the start or end of a JSON
+   * object or to a field name.
+   *
+   * @param destination destination object
+   * @param customizeParser optional parser customizer or {@code null} for none
+   */
+  @Beta
+  public final void parseAndClose(Object destination, CustomizeJsonParser customizeParser)
+          throws IOException {
+    try {
+      parse(destination, customizeParser);
+    } finally {
+      close();
+    }
+  }
+
+  /**
    * Skips the values of all keys in the current object until it finds the given key.
    *
    * <p>Before this method is called, the parser must either point to the start or end of a JSON
@@ -244,41 +279,6 @@ public abstract class JsonParser implements Closeable {
         break;
     }
     return currentToken;
-  }
-
-  /**
-   * Parse a JSON Object from the given JSON parser -- which is closed after parsing completes --
-   * into the given destination object.
-   *
-   * <p>Before this method is called, the parser must either point to the start or end of a JSON
-   * object or to a field name.
-   *
-   * @param destination destination object
-   * @since 1.15
-   */
-  public final void parseAndClose(Object destination) throws IOException {
-    parseAndClose(destination, null);
-  }
-
-  /**
-   * {@link Beta} <br>
-   * Parse a JSON Object from the given JSON parser -- which is closed after parsing completes --
-   * into the given destination object, optionally using the given parser customizer.
-   *
-   * <p>Before this method is called, the parser must either point to the start or end of a JSON
-   * object or to a field name.
-   *
-   * @param destination destination object
-   * @param customizeParser optional parser customizer or {@code null} for none
-   */
-  @Beta
-  public final void parseAndClose(Object destination, CustomizeJsonParser customizeParser)
-      throws IOException {
-    try {
-      parse(destination, customizeParser);
-    } finally {
-      close();
-    }
   }
 
   /**

--- a/google-http-client/src/main/java/com/google/api/client/testing/http/MockLowLevelHttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/testing/http/MockLowLevelHttpResponse.java
@@ -108,6 +108,16 @@ public class MockLowLevelHttpResponse extends LowLevelHttpResponse {
   }
 
   /**
+   * Sets the input stream content of HTTP response or {@code null} for none.
+   *
+   * @since 1.5
+   */
+  public MockLowLevelHttpResponse setContent(InputStream content) {
+    this.content = content;
+    return this;
+  }
+
+  /**
    * Sets the content to {@code null} and the content length to 0. Note that the result will have a
    * content length header whose value is 0.
    *
@@ -213,16 +223,6 @@ public class MockLowLevelHttpResponse extends LowLevelHttpResponse {
    */
   public MockLowLevelHttpResponse setHeaderValues(List<String> headerValues) {
     this.headerValues = Preconditions.checkNotNull(headerValues);
-    return this;
-  }
-
-  /**
-   * Sets the input stream content of HTTP response or {@code null} for none.
-   *
-   * @since 1.5
-   */
-  public MockLowLevelHttpResponse setContent(InputStream content) {
-    this.content = content;
     return this;
   }
 

--- a/google-http-client/src/main/java/com/google/api/client/util/ArrayMap.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/ArrayMap.java
@@ -170,6 +170,16 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Cloneable {
     return removeFromDataIndexOfKey(index << 1);
   }
 
+  /**
+   * Removes the key-value pair of the given key, or ignore if the key cannot be found.
+   *
+   * @return previous value or {@code null} for none
+   */
+  @Override
+  public final V remove(Object key) {
+    return removeFromDataIndexOfKey(getDataIndexOfKey(key));
+  }
+
   /** Returns whether there is a mapping for the given key. */
   @Override
   public final boolean containsKey(Object key) {
@@ -202,16 +212,6 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Cloneable {
       index = this.size;
     }
     return set(index, key, value);
-  }
-
-  /**
-   * Removes the key-value pair of the given key, or ignore if the key cannot be found.
-   *
-   * @return previous value or {@code null} for none
-   */
-  @Override
-  public final V remove(Object key) {
-    return removeFromDataIndexOfKey(getDataIndexOfKey(key));
   }
 
   /** Trims the internal array storage to minimize memory usage. */

--- a/google-http-client/src/main/java/com/google/api/client/util/Lists.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Lists.java
@@ -36,20 +36,6 @@ public final class Lists {
   }
 
   /**
-   * Creates an {@code ArrayList} instance backed by an array of the <i>exact</i> size specified;
-   * equivalent to {@link ArrayList#ArrayList(int)}.
-   *
-   * @param initialArraySize the exact size of the initial backing array for the returned array list
-   *     ({@code ArrayList} documentation calls this value the "capacity")
-   * @return a new, empty {@code ArrayList} which is guaranteed not to resize itself unless its size
-   *     reaches {@code initialArraySize + 1}
-   * @throws IllegalArgumentException if {@code initialArraySize} is negative
-   */
-  public static <E> ArrayList<E> newArrayListWithCapacity(int initialArraySize) {
-    return new ArrayList<E>(initialArraySize);
-  }
-
-  /**
    * Returns a new mutable {@code ArrayList} instance containing the given elements.
    *
    * @param elements the elements that the list should contain, in order
@@ -73,6 +59,20 @@ public final class Lists {
       list.add(elements.next());
     }
     return list;
+  }
+
+  /**
+   * Creates an {@code ArrayList} instance backed by an array of the <i>exact</i> size specified;
+   * equivalent to {@link ArrayList#ArrayList(int)}.
+   *
+   * @param initialArraySize the exact size of the initial backing array for the returned array list
+   *     ({@code ArrayList} documentation calls this value the "capacity")
+   * @return a new, empty {@code ArrayList} which is guaranteed not to resize itself unless its size
+   *     reaches {@code initialArraySize + 1}
+   * @throws IllegalArgumentException if {@code initialArraySize} is negative
+   */
+  public static <E> ArrayList<E> newArrayListWithCapacity(int initialArraySize) {
+    return new ArrayList<E>(initialArraySize);
   }
 
   private Lists() {}

--- a/google-http-client/src/main/java/com/google/api/client/util/escape/UnicodeEscaper.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/escape/UnicodeEscaper.java
@@ -62,6 +62,22 @@ public abstract class UnicodeEscaper extends Escaper {
   protected abstract char[] escape(int cp);
 
   /**
+   * Returns the escaped form of a given literal string.
+   *
+   * <p>If you are escaping input in arbitrary successive chunks, then it is not generally safe to
+   * use this method. If an input string ends with an unmatched high surrogate character, then this
+   * method will throw {@link IllegalArgumentException}. You should ensure your input is valid <a
+   * href="http://en.wikipedia.org/wiki/UTF-16">UTF-16</a> before calling this method.
+   *
+   * @param string the literal string to be escaped
+   * @return the escaped form of {@code string}
+   * @throws NullPointerException if {@code string} is null
+   * @throws IllegalArgumentException if invalid surrogate characters are encountered
+   */
+  @Override
+  public abstract String escape(String string);
+
+  /**
    * Scans a sub-sequence of characters from a given {@link CharSequence}, returning the index of
    * the next character that requires escaping.
    *
@@ -84,22 +100,6 @@ public abstract class UnicodeEscaper extends Escaper {
    *     surrogate pairs
    */
   protected abstract int nextEscapeIndex(CharSequence csq, int start, int end);
-
-  /**
-   * Returns the escaped form of a given literal string.
-   *
-   * <p>If you are escaping input in arbitrary successive chunks, then it is not generally safe to
-   * use this method. If an input string ends with an unmatched high surrogate character, then this
-   * method will throw {@link IllegalArgumentException}. You should ensure your input is valid <a
-   * href="http://en.wikipedia.org/wiki/UTF-16">UTF-16</a> before calling this method.
-   *
-   * @param string the literal string to be escaped
-   * @return the escaped form of {@code string}
-   * @throws NullPointerException if {@code string} is null
-   * @throws IllegalArgumentException if invalid surrogate characters are encountered
-   */
-  @Override
-  public abstract String escape(String string);
 
   /**
    * Returns the escaped form of a given literal string, starting at the given index. This method is


### PR DESCRIPTION
Fixes the following OverloadMethodsDeclarationOrder warnings:

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/http/AbstractHttpContent.java:128: Overload methods should not be split. Previous overloaded method located at line '110'. [OverloadMethodsDeclarationOrder]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java:454: Overload methods should not be split. Previous overloaded method located at line '424'. [OverloadMethodsDeclarationOrder]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpResponse.java:106: Overload methods should not be split. Previous overloaded method located at line '92'. [OverloadMethodsDeclarationOrder]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpTransport.java:176: Overload methods should not be split. Previous overloaded method located at line '149'. [OverloadMethodsDeclarationOrder]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/http/HttpTransport.java:141: Overload methods should not be split. Previous overloaded method located at line '114'. [OverloadMethodsDeclarationOrder]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java:583: Overload methods should not be split. Previous overloaded method located at line '378'. [OverloadMethodsDeclarationOrder]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/json/JsonFactory.java:148: Overload methods should not be split. Previous overloaded method located at line '108'. [OverloadMethodsDeclarationOrder]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java:259: Overload methods should not be split. Previous overloaded method located at line '160'. [OverloadMethodsDeclarationOrder]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/util/Lists.java:58: Overload methods should not be split. Previous overloaded method located at line '34'. [OverloadMethodsDeclarationOrder]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/util/escape/UnicodeEscaper.java:101: Overload methods should not be split. Previous overloaded method located at line '62'. [OverloadMethodsDeclarationOrder]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/util/ArrayMap.java:212: Overload methods should not be split. Previous overloaded method located at line '169'. [OverloadMethodsDeclarationOrder]

> [WARN] /home/anusien/opensource/google-http-java-client/google-http-client/src/main/java/com/google/api/client/testing/http/MockLowLevelHttpResponse.java:224: Overload methods should not be split. Previous overloaded method located at line '101'. [OverloadMethodsDeclarationOrder]