### PR TITLE
feat: add option to pass redirect Location: header value as-is without encoding, decoding, or escaping

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
@@ -80,7 +80,11 @@ public class GenericUrl extends GenericData {
   /** Fragment component or {@code null} for none. */
   private String fragment;
 
-  /** When true the URL is used `as is` (without encoding, decoding and escaping)
+  /**
+    * If true, the URL string originally given is used as is (without encoding, decoding and
+    * escaping) whenever referenced; otherwise, part of the URL string may be encoded or decoded as
+    * deemed appropriate or necessary.
+    */
   private boolean verbatim;
 
   public GenericUrl() {}

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -141,7 +141,7 @@ public final class HttpRequest {
 
   /** HTTP request URL. */
   private GenericUrl url;
-
+  
   /** Timeout in milliseconds to establish a connection or {@code 0} for an infinite timeout. */
   private int connectTimeout = 20 * 1000;
 
@@ -172,8 +172,11 @@ public final class HttpRequest {
   /** The {@link BackOffPolicy} to use between retry attempts or {@code null} for none. */
   @Deprecated @Beta private BackOffPolicy backOffPolicy;
 
-  /** Whether to automatically follow redirects ({@code true} by default). */
+ /** Whether to automatically follow redirects ({@code true} by default). */
   private boolean followRedirects = true;
+
+  /** Whether to use raw redirect URLs ({@code false} by default). */
+  private boolean useRawRedirectUrls = false;
 
   /**
    * Whether to throw an exception at the end of {@link #execute()} on an HTTP error code (non-2XX)
@@ -696,6 +699,23 @@ public final class HttpRequest {
   }
 
   /**
+   * Return whether to use raw redirect URLs. 
+   */
+  public boolean getUseRawRedirectUrls() {
+    return useRawRedirectUrls;
+  }
+
+  /**
+   * Sets whether to use raw redirect URLs. 
+   *
+   * <p>The default value is {@code false}.
+   */
+  public HttpRequest setUseRawRedirectUrls(boolean useRawRedirectUrls) {
+    this.useRawRedirectUrls = useRawRedirectUrls;
+    return this;
+  }
+
+  /**
    * Returns whether to throw an exception at the end of {@link #execute()} on an HTTP error code
    * (non-2XX) after all retries and response handlers have been exhausted.
    *
@@ -1159,7 +1179,7 @@ public final class HttpRequest {
         && HttpStatusCodes.isRedirect(statusCode)
         && redirectLocation != null) {
       // resolve the redirect location relative to the current location
-      setUrl(new GenericUrl(url.toURL(redirectLocation)));
+      setUrl(new GenericUrl(url.toURL(redirectLocation), useRawRedirectUrls));
       // on 303 change method to GET
       if (statusCode == HttpStatusCodes.STATUS_CODE_SEE_OTHER) {
         setRequestMethod(HttpMethods.GET);

--- a/google-http-client/src/main/java/com/google/api/client/http/UriTemplate.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/UriTemplate.java
@@ -318,7 +318,7 @@ public class UriTemplate {
     }
     if (addUnusedParamsAsQueryParams) {
       // Add the parameters remaining in the variableMap as query parameters.
-      GenericUrl.addQueryParams(variableMap.entrySet(), pathBuf);
+      GenericUrl.addQueryParams(variableMap.entrySet(), pathBuf, false);
     }
     return pathBuf.toString();
   }

--- a/google-http-client/src/test/java/com/google/api/client/http/GenericUrlTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/GenericUrlTest.java
@@ -150,6 +150,10 @@ public class GenericUrlTest extends TestCase {
     public TestUrl(String encodedUrl) {
       super(encodedUrl);
     }
+
+    public TestUrl(String encodedUrl, boolean verbatim) {
+      super(encodedUrl, verbatim);
+    }
   }
 
   private static final String FULL =
@@ -191,6 +195,12 @@ public class GenericUrlTest extends TestCase {
     assertNull(url.hidden);
     assertEquals("bar", url.get("foo"));
     assertEquals("bar", url.foo);
+  }
+
+  public void testParse_full_verbatim() {
+    TestUrl url = new TestUrl(FULL, true);
+    assertNull(url.hidden);
+    assertEquals("Go%3D%23/%25%26%20?%3Co%3Egle", url.getFirst("q"));
   }
 
   public void testConstructor_url() throws MalformedURLException {
@@ -473,7 +483,7 @@ public class GenericUrlTest extends TestCase {
   }
 
   private void subtestToPathParts(String encodedPath, String... expectedDecodedParts) {
-    List<String> result = GenericUrl.toPathParts(encodedPath);
+    List<String> result = GenericUrl.toPathParts(encodedPath, false);
     if (encodedPath == null) {
       assertNull(result);
     } else {


### PR DESCRIPTION
Fixes #864 

At the moment I have no actual way to test it, as I failed to use `1.33.1-SNAPSHOT` with Jib (any helping hand is more than welcome).