### PR TITLE
Adding test for Gregorian Calendar beginning day

### DIFF
--- a/google-http-client/src/test/java/com/google/api/client/util/DateTimeTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/DateTimeTest.java
@@ -148,6 +148,11 @@ public class DateTimeTest extends TestCase {
         DateTime.parseRfc3339(
             "2018-12-31T23:59:59.9999Z"), // This value would be truncated prior to version 1.30.2
         DateTime.parseRfc3339("2018-12-31T23:59:59.999Z"));
+
+    // The beginning of Gregorian Calendar
+    assertEquals(
+        -12219287774877L, // Result from Joda time's Instant.parse
+        DateTime.parseRfc3339("1582-10-15T01:23:45.123Z").getValue());
   }
 
   /**


### PR DESCRIPTION
Follow up of https://github.com/googleapis/google-http-java-client/pull/895#discussion_r350369850 .

# Why is 1582-10-15 special?

It's because the calendar system has changed from Julian to Gregorian on that day. The 10 days before that day have been skipped to adjust the difference between Gregorian calendar and Julian calendar.

> the calendar's adoption, Friday, 15 October 1582, the preceding date was Thursday, 4 October 1582 (Julian calendar).

https://en.wikipedia.org/wiki/Gregorian_calendar
