### PR TITLE
Libraries-bom 3.1.0 release

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,7 +23,7 @@ the `dependencyManagement` section of your `pom.xml`:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0</version>
       <type>pom</type>
       <scope>import</scope>
      </dependency>


### PR DESCRIPTION
Libraries-bom 3.1.0 has been released. https://search.maven.org/artifact/com.google.cloud/libraries-bom/3.1.0/pom


Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for context and/or discussion)