### PR TITLE
fix: incorrect check for Windows OS in FileDataStoreFactory

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/store/FileDataStoreFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/store/FileDataStoreFactory.java
@@ -53,7 +53,7 @@ public class FileDataStoreFactory extends AbstractDataStoreFactory {
   private static final Logger LOGGER = Logger.getLogger(FileDataStoreFactory.class.getName());
 
   private static final boolean IS_WINDOWS = StandardSystemProperty.OS_NAME.value()
-      .startsWith("WINDOWS");
+      .regionMatches(true, 0, "WINDOWS", 0, "WINDOWS".length());
 
   /** Directory to store data. */
   private final File dataDirectory;

--- a/google-http-client/src/main/java/com/google/api/client/util/store/FileDataStoreFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/store/FileDataStoreFactory.java
@@ -36,6 +36,7 @@ import java.nio.file.attribute.FileOwnerAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -54,7 +55,7 @@ public class FileDataStoreFactory extends AbstractDataStoreFactory {
   private static final Logger LOGGER = Logger.getLogger(FileDataStoreFactory.class.getName());
 
   private static final boolean IS_WINDOWS = StandardSystemProperty.OS_NAME.value()
-      .regionMatches(true, 0, "WINDOWS", 0, "WINDOWS".length());
+      .toLowerCase(Locale.ENGLISH).startsWith("windows");
 
   /** Directory to store data. */
   private final File dataDirectory;

--- a/google-http-client/src/main/java/com/google/api/client/util/store/FileDataStoreFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/store/FileDataStoreFactory.java
@@ -32,6 +32,7 @@ import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.AclEntryPermission;
 import java.nio.file.attribute.AclEntryType;
 import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.FileOwnerAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.HashSet;
@@ -155,8 +156,8 @@ public class FileDataStoreFactory extends AbstractDataStoreFactory {
 
   static void setPermissionsToOwnerOnlyWindows(File file) throws IOException {
     Path path = Paths.get(file.getAbsolutePath());
-    UserPrincipal owner = path.getFileSystem().getUserPrincipalLookupService()
-        .lookupPrincipalByName("OWNER@");
+    FileOwnerAttributeView fileAttributeView = Files.getFileAttributeView(path, FileOwnerAttributeView.class);
+    UserPrincipal owner = fileAttributeView.getOwner();
 
     // get view
     AclFileAttributeView view = Files.getFileAttributeView(path, AclFileAttributeView.class);


### PR DESCRIPTION
The "Windows" part of `os.name` is not always uppercase. On Windows 10 for example I get `"Windows 10"`, which does not pass the current check. This leads to `setPermissionsToOwnerOnly` instead of `setPermissionsToOwnerOnlyWindows` being executed, which then issues the following warning (and does nothing): `Unable to set permissions for C:\example, because you are running on a non-POSIX file system`

Fixes #953 