### PR TITLE
deps: move more up to date dependencies first

### DIFF
--- a/google-http-client-android/pom.xml
+++ b/google-http-client-android/pom.xml
@@ -49,14 +49,14 @@
   </build>
   <dependencies>
     <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.android</groupId>
       <artifactId>android</artifactId>
       <version>4.1.1.4</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client</artifactId>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
@kolea2 This has the effect of upgrading commons-logging to 1.2 from 1.1.1
