### PR TITLE
fix for #982

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
+++ b/google-http-client/src/main/java/com/google/api/client/json/JsonParser.java
@@ -717,7 +717,7 @@ public abstract class JsonParser implements Closeable {
     // value type is now null, class, parameterized type, or generic array type
     JsonToken token = getCurrentToken();
     try {
-      switch (getCurrentToken()) {
+      switch (token) {
         case START_ARRAY:
         case END_ARRAY:
           boolean isArray = Types.isArray(valueType);


### PR DESCRIPTION
changed switch parameter in parseValue from calling getCurrentToken() again to just declared and assigned local member "token" two lines above

Fixes #982 