### PR TITLE
add http.status_code attribute to all Spans that have a lowLevelHttpResponse 

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -1012,6 +1012,7 @@ public final class HttpRequest {
         LowLevelHttpResponse lowLevelHttpResponse = lowLevelHttpRequest.execute();
         if (lowLevelHttpResponse != null) {
           OpenCensusUtils.recordReceivedMessageEvent(span, lowLevelHttpResponse.getContentLength());
+          span.putAttribute(HttpTraceAttributeConstants.HTTP_STATUS_CODE, AttributeValue.longAttributeValue(lowLevelHttpResponse.getStatusCode()));
         }
         // Flag used to indicate if an exception is thrown before the response is constructed.
         boolean responseConstructed = false;

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTracingTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTracingTest.java
@@ -82,6 +82,7 @@ public class HttpRequestTracingTest {
     assertAttributeEquals(span, "http.host", "google.com");
     assertAttributeEquals(span, "http.url", "https://google.com/");
     assertAttributeEquals(span, "http.method", "GET");
+    assertAttributeEquals(span, "http.status_code", "200");
 
     // Ensure we have a single annotation for starting the first attempt
     assertEquals(1, span.getAnnotations().getEvents().size());


### PR DESCRIPTION
This one is fairly straight forward:
It adds the official OpenTelemetry http.status_code attribute which is [mandatory](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-http.md
), was missing and is very useful to know what happened to one's request.

Signed-off-by: CI-Bot for Emmanuel Courreges <emmanuel.courreges@orange.com>
