### PR TITLE
fix: Correctly handling chunked response streams with gzip

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -354,10 +354,10 @@ public final class HttpResponse {
             String oontentencoding = this.contentEncoding.trim().toLowerCase(Locale.ENGLISH);
             if (CONTENT_ENCODING_GZIP.equals(oontentencoding) || CONTENT_ENCODING_XGZIP.equals(oontentencoding)) {
               // Wrap the original stream in a ConsumingInputStream before passing it to
-              // GZIPInputStream.
-              // GZIPInputStream tends to leave content in the original stream (it will almost
-              // always leave the last chunk unconsumed in chunked responses). ConsumingInputStream
-              // ensures that any unconsumed bytes are read at close.
+              // GZIPInputStream. The GZIPInputStream leaves content unconsumed in the original
+              // stream (it almost always leaves the last chunk unconsumed in chunked responses).
+              // ConsumingInputStream ensures that any unconsumed bytes are read at close.
+              // GZIPInputStream.close() --> ConsumingInputStream.close() --> exhaust(ConsumingInputStream)
               lowLevelResponseContent =
                   new GZIPInputStream(new ConsumingInputStream(lowLevelResponseContent));
             }

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -353,8 +353,13 @@ public final class HttpResponse {
           if (!returnRawInputStream && this.contentEncoding != null) {
             String oontentencoding = this.contentEncoding.trim().toLowerCase(Locale.ENGLISH);
             if (CONTENT_ENCODING_GZIP.equals(oontentencoding) || CONTENT_ENCODING_XGZIP.equals(oontentencoding)) {
+              // Wrap the original stream in a ConsumingInputStream before passing it to
+              // GZIPInputStream.
+              // GZIPInputStream tends to leave content in the original stream (it will almost
+              // always leave the last chunk unconsumed in chunked responses). ConsumingInputStream
+              // ensures that any unconsumed bytes are read at close.
               lowLevelResponseContent =
-                  new ConsumingInputStream(new GZIPInputStream(lowLevelResponseContent));
+                  new GZIPInputStream(new ConsumingInputStream(lowLevelResponseContent));
             }
           }
           // logging (wrap content with LoggingInputStream)

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
@@ -25,7 +25,6 @@ import com.google.api.client.util.Key;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;


### PR DESCRIPTION
Fixes #367 (see my last comment on that issue)

The fix done in #840 is incorrect if not inadequate. It doesn't properly cleanup the last chunk of a chunked response when the response is also gzipped. This in turns prevents proper connection reuse. 

This PR addresses this issue.