### PR TITLE
docs: require Android 4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ content. The JSON and XML libraries are also fully pluggable, and they include s
 
 The library supports the following Java environments:
 
-- Java 7 (or higher)
-- Android 4.0 (Ice Cream Sandwich) (or higher)
+- Java 7 or higher
+- Android 4.4 (Kit Kat)
 - GoogleAppEngine Google App Engine
 
 The following related projects are built on the Google HTTP Client Library for Java:


### PR DESCRIPTION
@chingor13 @BenWhitehead We now require API 19 or higher which means Android 4.4 or later.
