### PR TITLE
Use the provided Charsets class 

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/StringUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/StringUtils.java
@@ -15,7 +15,7 @@
 package com.google.api.client.util;
 
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
+import com.google.api.client.util.Charsets;
 
 /**
  * Utilities for strings.
@@ -48,7 +48,7 @@ public class StringUtils {
     if (string == null) {
       return null;
     }
-    return string.getBytes(StandardCharsets.UTF_8);
+    return string.getBytes(Charsets.UTF_8);
   }
 
   /**
@@ -66,7 +66,7 @@ public class StringUtils {
     if (bytes == null) {
       return null;
     }
-    return new String(bytes, StandardCharsets.UTF_8);
+    return new String(bytes, Charsets.UTF_8);
   }
 
   private StringUtils() {}

--- a/google-http-client/src/main/java/com/google/api/client/util/escape/CharEscapers.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/escape/CharEscapers.java
@@ -15,9 +15,9 @@
 
 package com.google.api.client.util.escape;
 
+import com.google.api.client.util.Charsets;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Utility functions for encoding and decoding URIs.
@@ -119,7 +119,7 @@ public final class CharEscapers {
    */
   public static String decodeUri(String uri) {
     try {
-      return URLDecoder.decode(uri, StandardCharsets.UTF_8.name());
+      return URLDecoder.decode(uri, Charsets.UTF_8.name());
     } catch (UnsupportedEncodingException e) {
       // UTF-8 encoding guaranteed to be supported by JVM
       throw new RuntimeException(e);
@@ -141,7 +141,7 @@ public final class CharEscapers {
       return null;
     }
     try {
-      return URLDecoder.decode(path.replace("+", "%2B"), StandardCharsets.UTF_8.name());
+      return URLDecoder.decode(path.replace("+", "%2B"), Charsets.UTF_8.name());
     } catch (UnsupportedEncodingException e) {
       // UTF-8 encoding guaranteed to be supported by JVM
       throw new RuntimeException(e);

--- a/google-http-client/src/test/java/com/google/api/client/http/ConsumingInputStreamTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/ConsumingInputStreamTest.java
@@ -18,16 +18,17 @@ package com.google.api.client.http;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.api.client.util.Charsets;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+
 import org.junit.Test;
 
 public class ConsumingInputStreamTest {
 
   @Test
   public void testClose_drainsBytesOnClose() throws IOException {
-    MockInputStream mockInputStream = new MockInputStream("abc123".getBytes(StandardCharsets.UTF_8));
+    MockInputStream mockInputStream = new MockInputStream("abc123".getBytes(Charsets.UTF_8));
     InputStream consumingInputStream = new ConsumingInputStream(mockInputStream);
 
     assertEquals(6, mockInputStream.getBytesToRead());

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpResponseTest.java
@@ -22,11 +22,11 @@ import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.client.testing.util.LogRecordingHandler;
 import com.google.api.client.testing.util.TestableByteArrayInputStream;
 import com.google.api.client.util.Key;
+import com.google.api.client.util.Charsets;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.Locale;
@@ -559,7 +559,7 @@ public class HttpResponseTest extends TestCase {
   }
 
   private void do_testGetContent_gzipEncoding_finishReading(String contentEncoding) throws IOException {
-    byte[] dataToCompress = "abcd".getBytes(StandardCharsets.UTF_8);
+    byte[] dataToCompress = "abcd".getBytes(Charsets.UTF_8);
     byte[] mockBytes;
     try (
         ByteArrayOutputStream byteStream = new ByteArrayOutputStream(dataToCompress.length);

--- a/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpRequestTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpRequestTest.java
@@ -9,12 +9,12 @@ import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.http.javanet.NetHttpRequest.OutputWriter;
 import com.google.api.client.testing.http.HttpTesting;
 import com.google.api.client.testing.http.javanet.MockHttpURLConnection;
+import com.google.api.client.util.Charsets;
 import com.google.api.client.util.StreamingContent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 
@@ -225,7 +225,7 @@ public class NetHttpRequestTest {
     connection.setRequestMethod("POST");
     NetHttpRequest request = new NetHttpRequest(connection);
     HttpContent content =
-        new ByteArrayContent("text/plain", "sample".getBytes(StandardCharsets.UTF_8));
+        new ByteArrayContent("text/plain", "sample".getBytes(Charsets.UTF_8));
     request.setStreamingContent(content);
     request.setContentLength(content.getLength());
     request.execute();

--- a/google-http-client/src/test/java/com/google/api/client/util/Base64Test.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/Base64Test.java
@@ -14,7 +14,7 @@
 
 package com.google.api.client.util;
 
-import java.nio.charset.StandardCharsets;
+import com.google.api.client.util.Charsets;
 import junit.framework.TestCase;
 
 /**
@@ -26,19 +26,19 @@ public class Base64Test extends TestCase {
 
   public void test_decodeBase64_withPadding() {
     String encoded = "Zm9vOmJhcg==";
-    assertEquals("foo:bar", new String(Base64.decodeBase64(encoded), StandardCharsets.UTF_8));
+    assertEquals("foo:bar", new String(Base64.decodeBase64(encoded), Charsets.UTF_8));
   }
 
   public void test_decodeBase64_withoutPadding() {
     String encoded = "Zm9vOmJhcg";
-    assertEquals("foo:bar", new String(Base64.decodeBase64(encoded), StandardCharsets.UTF_8));
+    assertEquals("foo:bar", new String(Base64.decodeBase64(encoded), Charsets.UTF_8));
   }
 
   public void test_decodeBase64_withTrailingWhitespace() {
     // Some internal use cases append extra space characters that apache-commons base64 decoding
     // previously handled.
     String encoded = "Zm9vOmJhcg==\r\n";
-    assertEquals("foo:bar", new String(Base64.decodeBase64(encoded), StandardCharsets.UTF_8));
+    assertEquals("foo:bar", new String(Base64.decodeBase64(encoded), Charsets.UTF_8));
   }
 
   public void test_decodeBase64_withNullBytes_shouldReturnNull() {


### PR DESCRIPTION
instead of the StandardCharsets coming from Java 8 - to restore Android API 14 (aka Android 4.0) compatibility

Fixes #926