### PR TITLE
set minimum API level to 19 a.k.a. 4.4 Kit Kat

### DIFF
--- a/google-http-client-android/AndroidManifest.xml
+++ b/google-http-client-android/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="4"
-        android:targetSdkVersion="4" />
+        android:minSdkVersion="19"
+        android:targetSdkVersion="19" />
 
 </manifest>


### PR DESCRIPTION
@chingor13 hard to believe this was set to Android 1.6, Donut.

fixes #1015
