### PR TITLE
chore(docs): libraries-bom 7.0.0

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,7 +23,7 @@ the `dependencyManagement` section of your `pom.xml`:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>5.5.0</version>
+      <version>7.0.0</version>
       <type>pom</type>
       <scope>import</scope>
      </dependency>


### PR DESCRIPTION
Libraries BOM 7.0.0 https://search.maven.org/artifact/com.google.cloud/libraries-bom/7.0.0/pom
(It's 7.0.0 because I messed up the 6.0.0 version.)

@chingor13 @elharo  Would you review and merge this?