### PR TITLE
deps: libraries-bom 9.0.0

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,7 +23,7 @@ the `dependencyManagement` section of your `pom.xml`:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>8.1.0</version>
+      <version>9.0.0</version>
       <type>pom</type>
       <scope>import</scope>
      </dependency>


### PR DESCRIPTION
Libraries BOM 9.0.0 is available now In Maven Central: https://search.maven.org/artifact/com.google.cloud/libraries-bom/9.0.0/pom