### PR TITLE
deps: version manage error_prone_annotations to 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,11 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>2.5.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-api-1.0-sdk</artifactId>
         <version>${project.appengine.version}</version>


### PR DESCRIPTION
Fixes the dependencies presubmits
