### PR TITLE
ci: removing Kokoro settings that are covered by GitHub Actions

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -37,7 +37,6 @@ branchProtectionRules:
     - "linkage-monitor"
     - "lint"
     - "clirr"
-    - "Kokoro - Test: Binary Compatibility"
     - "cla/google"
 
 # List of explicit permissions to add (additive only)

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -32,6 +32,8 @@ branchProtectionRules:
     - "units (8)"
     - "units (11)"
     - "windows"
+    - "dependencies (8)"
+    - "dependencies (11)"
     - "linkage-monitor"
     - "lint"
     - "clirr"

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -28,11 +28,13 @@ branchProtectionRules:
   requiresStrictStatusChecks: false
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
-    - "Kokoro - Test: Binary Compatibility"
-    - "Kokoro - Test: Java 11"
-    - "Kokoro - Test: Java 7"
-    - "Kokoro - Test: Java 8"
-    - "Kokoro - Test: Linkage Monitor"
+    - "units (7)"
+    - "units (8)"
+    - "units (11)"
+    - "windows"
+    - "linkage-monitor"
+    - "lint"
+    - "clirr"
     - "cla/google"
 
 # List of explicit permissions to add (additive only)

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -35,6 +35,7 @@ branchProtectionRules:
     - "linkage-monitor"
     - "lint"
     - "clirr"
+    - "Kokoro - Test: Binary Compatibility"
     - "cla/google"
 
 # List of explicit permissions to add (additive only)


### PR DESCRIPTION
The GitHub Actions have been enabled in this repository. I believe we no longer need the Kokoro builds here.

---

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-http-java-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
