### PR TITLE
fix: remove old broken link

### DIFF
--- a/google-http-client-jackson2/src/main/java/com/google/api/client/json/jackson2/package-info.java
+++ b/google-http-client-jackson2/src/main/java/com/google/api/client/json/jackson2/package-info.java
@@ -13,8 +13,7 @@
  */
 
 /**
- * Low-level implementation of the JSON parser library based on the <a
- * href="http://wiki.fasterxml.com/JacksonRelease20">Jackson 2</a> JSON library.
+ * Low-level implementation of the JSON parser library based on the Jackson 2 JSON library.
  *
  * @since 1.11
  * @author Yaniv Inbar


### PR DESCRIPTION
Perhaps this is the one causing us trouble in the Java 11 CI check. In any case the link I remove here is 404.

Fixes #1278 