### PR TITLE
deps: adding error prone annotations to dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,6 @@
         <version>${project.opencensus.version}</version>
       </dependency>
       <dependency>
-        <!-- We can remove this once Guava depends on the newer error_prone_annotations -->
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>${project.errorprone.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,12 @@
         <artifactId>opencensus-testing</artifactId>
         <version>${project.opencensus.version}</version>
       </dependency>
+      <dependency>
+        <!-- We can remove this once Guava depends on the newer error_prone_annotations -->
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>${project.errorprone.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -584,6 +590,7 @@
     <project.httpclient.version>4.5.13</project.httpclient.version>
     <project.httpcore.version>4.4.14</project.httpcore.version>
     <project.opencensus.version>0.28.0</project.opencensus.version>
+    <project.errorprone.version>2.5.1</project.errorprone.version>
     <project.root-directory>..</project.root-directory>
     <deploy.autorelease>false</deploy.autorelease>
   </properties>


### PR DESCRIPTION
"ci / dependencies" was failing in this repository due to the error prone annotation version between Guava and Truth.

<img width="588" alt="Screen Shot 2021-02-23 at 11 28 33" src="https://user-images.githubusercontent.com/28604/108874568-46680d80-75ca-11eb-9b92-d4845ca6bc53.png">


```
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-maven) @ google-http-client ---
Warning:  Rule 2: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.google.errorprone:error_prone_annotations:2.3.4 paths to dependency are:
+-com.google.http-client:google-http-client:1.38.2-SNAPSHOT
  +-com.google.guava:guava:30.1-android
    +-com.google.errorprone:error_prone_annotations:2.3.4
and
+-com.google.http-client:google-http-client:1.38.2-SNAPSHOT
  +-com.google.guava:guava-testlib:30.1-android
    +-com.google.errorprone:error_prone_annotations:2.3.4
and
+-com.google.http-client:google-http-client:1.38.2-SNAPSHOT
  +-com.google.truth:truth:1.1.2
    +-com.google.errorprone:error_prone_annotations:2.5.1
]
```

---

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-http-java-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1276  ☕️
