### PR TITLE
refactor: switch IOUtils.copy to ByteStreams.copy

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -14,10 +14,10 @@
 
 package com.google.api.client.http;
 
-import com.google.api.client.util.IOUtils;
 import com.google.api.client.util.LoggingInputStream;
 import com.google.api.client.util.Preconditions;
 import com.google.api.client.util.StringUtils;
+import com.google.common.io.ByteStreams;
 import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
@@ -414,7 +414,7 @@ public final class HttpResponse {
    */
   public void download(OutputStream outputStream) throws IOException {
     InputStream inputStream = getContent();
-    IOUtils.copy(inputStream, outputStream);
+    ByteStreams.copy(inputStream, outputStream);
   }
 
   /** Closes the content of the HTTP response from {@link #getContent()}, ignoring any content. */
@@ -501,7 +501,7 @@ public final class HttpResponse {
       return "";
     }
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    IOUtils.copy(content, out);
+    ByteStreams.copy(content, out);
     return out.toString(getContentCharset().name());
   }
 

--- a/google-http-client/src/main/java/com/google/api/client/testing/http/MockLowLevelHttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/testing/http/MockLowLevelHttpRequest.java
@@ -18,7 +18,8 @@ import com.google.api.client.http.HttpMediaType;
 import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.util.Beta;
-import com.google.api.client.util.IOUtils;
+import com.google.common.io.ByteStreams;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -157,7 +158,7 @@ public class MockLowLevelHttpRequest extends LowLevelHttpRequest {
       InputStream contentInputStream =
           new GZIPInputStream(new ByteArrayInputStream(out.toByteArray()));
       out = new ByteArrayOutputStream();
-      IOUtils.copy(contentInputStream, out);
+      ByteStreams.copy(contentInputStream, out);
     }
     // determine charset parameter from content type
     String contentType = getContentType();

--- a/google-http-client/src/test/java/com/google/api/client/http/ByteArrayContentTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/ByteArrayContentTest.java
@@ -14,10 +14,11 @@
 
 package com.google.api.client.http;
 
-import com.google.api.client.util.IOUtils;
 import com.google.api.client.util.StringUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+
+import com.google.common.io.ByteStreams;
 import junit.framework.TestCase;
 
 /**
@@ -61,7 +62,7 @@ public class ByteArrayContentTest extends TestCase {
     assertTrue(content.retrySupported());
     assertEquals(expected.length(), content.getLength());
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    IOUtils.copy(content.getInputStream(), out);
+    ByteStreams.copy(content.getInputStream(), out);
     assertEquals(expected, out.toString());
   }
 }


### PR DESCRIPTION
`IOUtils.copy` is deprecated and should be replaced by `ByteStreams.copy` (it uses `ByteStreams.copy` internally).
