### PR TITLE
fix: when disconnecting, close the underlying connection before the response InputStream

### DIFF
--- a/google-http-client-apache-v2/src/test/java/com/google/api/client/http/apache/v2/ApacheHttpTransportTest.java
+++ b/google-http-client-apache-v2/src/test/java/com/google/api/client/http/apache/v2/ApacheHttpTransportTest.java
@@ -268,6 +268,8 @@ public class ApacheHttpTransportTest {
 
   @Test(timeout = 10_000L)
   public void testDisconnectShouldNotWaitToReadResponse() throws IOException {
+    // This handler waits for 100s before returning writing content. The test should
+    // timeout if disconnect waits for the response before closing the connection.
     final HttpHandler handler =
         new HttpHandler() {
           @Override

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -351,9 +351,9 @@ public final class HttpResponse {
         try {
           // gzip encoding (wrap content with GZipInputStream)
           if (!returnRawInputStream && this.contentEncoding != null) {
-            String oontentencoding = this.contentEncoding.trim().toLowerCase(Locale.ENGLISH);
-            if (CONTENT_ENCODING_GZIP.equals(oontentencoding)
-                || CONTENT_ENCODING_XGZIP.equals(oontentencoding)) {
+            String contentencoding = this.contentEncoding.trim().toLowerCase(Locale.ENGLISH);
+            if (CONTENT_ENCODING_GZIP.equals(contentencoding)
+                || CONTENT_ENCODING_XGZIP.equals(contentencoding)) {
               // Wrap the original stream in a ConsumingInputStream before passing it to
               // GZIPInputStream. The GZIPInputStream leaves content unconsumed in the original
               // stream (it almost always leaves the last chunk unconsumed in chunked responses).
@@ -432,8 +432,10 @@ public final class HttpResponse {
    * @since 1.4
    */
   public void disconnect() throws IOException {
-    ignore();
+    // Close the connection before trying to close the InputStream content. If you are trying to
+    // disconnect, we shouldn't need to try to read any further content.
     response.disconnect();
+    ignore();
   }
 
   /**

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -419,9 +419,12 @@ public final class HttpResponse {
 
   /** Closes the content of the HTTP response from {@link #getContent()}, ignoring any content. */
   public void ignore() throws IOException {
-    InputStream content = getContent();
-    if (content != null) {
-      content.close();
+    if (this.response == null) {
+      return;
+    }
+    InputStream lowLevelResponseContent = this.response.getContent();
+    if (lowLevelResponseContent != null) {
+      lowLevelResponseContent.close();
     }
   }
 

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -351,9 +351,9 @@ public final class HttpResponse {
         try {
           // gzip encoding (wrap content with GZipInputStream)
           if (!returnRawInputStream && this.contentEncoding != null) {
-            String contentencoding = this.contentEncoding.trim().toLowerCase(Locale.ENGLISH);
-            if (CONTENT_ENCODING_GZIP.equals(contentencoding)
-                || CONTENT_ENCODING_XGZIP.equals(contentencoding)) {
+            String contentEncoding = this.contentEncoding.trim().toLowerCase(Locale.ENGLISH);
+            if (CONTENT_ENCODING_GZIP.equals(contentEncoding)
+                || CONTENT_ENCODING_XGZIP.equals(contentEncoding)) {
               // Wrap the original stream in a ConsumingInputStream before passing it to
               // GZIPInputStream. The GZIPInputStream leaves content unconsumed in the original
               // stream (it almost always leaves the last chunk unconsumed in chunked responses).

--- a/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpTransportTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpTransportTest.java
@@ -195,6 +195,8 @@ public class NetHttpTransportTest extends TestCase {
 
   @Test(timeout = 10_000L)
   public void testDisconnectShouldNotWaitToReadResponse() throws IOException {
+    // This handler waits for 100s before returning writing content. The test should
+    // timeout if disconnect waits for the response before closing the connection.
     final HttpHandler handler =
         new HttpHandler() {
           @Override

--- a/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpTransportTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpTransportTest.java
@@ -14,17 +14,27 @@
 
 package com.google.api.client.http.javanet;
 
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.testing.http.HttpTesting;
 import com.google.api.client.testing.http.javanet.MockHttpURLConnection;
 import com.google.api.client.util.ByteArrayStreamingContent;
 import com.google.api.client.util.StringUtils;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
 import java.net.URL;
 import java.security.KeyStore;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Tests {@link NetHttpTransport}.
@@ -158,5 +168,60 @@ public class NetHttpTransportTest extends TestCase {
     request.setStreamingContent(new ByteArrayStreamingContent(bytes));
     request.setContentType(type);
     request.setContentLength(bytes.length);
+  }
+
+  static class FakeServer implements AutoCloseable {
+    private final HttpServer server;
+    private final ExecutorService executorService;
+
+    public FakeServer(HttpHandler httpHandler) throws IOException {
+      this.server = HttpServer.create(new InetSocketAddress(0), 0);
+      this.executorService = Executors.newFixedThreadPool(1);
+      server.setExecutor(this.executorService);
+      server.createContext("/", httpHandler);
+      server.start();
+    }
+
+    public int getPort() {
+      return server.getAddress().getPort();
+    }
+
+    @Override
+    public void close() {
+      this.server.stop(0);
+      this.executorService.shutdownNow();
+    }
+  }
+
+  @Test(timeout = 10_000L)
+  public void testDisconnectShouldNotWaitToReadResponse() throws IOException {
+    final HttpHandler handler =
+        new HttpHandler() {
+          @Override
+          public void handle(HttpExchange httpExchange) throws IOException {
+            byte[] response = httpExchange.getRequestURI().toString().getBytes();
+            httpExchange.sendResponseHeaders(200, response.length);
+
+            // Sleep for longer than the test timeout
+            try {
+              Thread.sleep(100_000);
+            } catch (InterruptedException e) {
+              throw new IOException("interrupted", e);
+            }
+            try (OutputStream out = httpExchange.getResponseBody()) {
+              out.write(response);
+            }
+          }
+        };
+
+    try (FakeServer server = new FakeServer(handler)) {
+      HttpTransport transport = new NetHttpTransport();
+      GenericUrl testUrl = new GenericUrl("http://localhost/foo//bar");
+      testUrl.setPort(server.getPort());
+      com.google.api.client.http.HttpResponse response =
+          transport.createRequestFactory().buildGetRequest(testUrl).execute();
+      // disconnect should not wait to read the entire content
+      response.disconnect();
+    }
   }
 }


### PR DESCRIPTION
Adds a test to the `NetHttpTransport` and `ApacheHttpTransport` to make sure we don't wait until all the content is read when disconnecting the response.

Fixes #1303
