### PR TITLE
fix: make dependency on javax.annotation optional (#1323)

### DIFF
--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -107,6 +107,11 @@
             </goals>   
           </execution>
         </executions>
+        <configuration>
+          <instructions>
+            <Import-Package>javax.annotation;resolution:=optional</Import-Package>
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
 


### PR DESCRIPTION
This PR changes the configuration of the `maven-bundle-plugin` so that the generated `MANIFEST.MF` declares the runtime depencency on `javax.annotation` as optional.

This way, OSGI environments try not to resolve `javax.annotation` from findbugs that could collide with `javax.annotation` from other bundles.

- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-http-java-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
> No source Code was changed
- [X] Appropriate docs were updated (if necessary)
> Not necessary

Fixes #1323  ☕️
