### PR TITLE
Inefficient Usage of ArrayList

### DIFF
--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonParser.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonParser.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -36,7 +37,7 @@ class GsonParser extends JsonParser {
   private final JsonReader reader;
   private final GsonFactory factory;
 
-  private List<String> currentNameStack = new ArrayList<String>();
+  private List<String> currentNameStack = new LinkedList<String>();
   private JsonToken currentToken;
   private String currentText;
 
@@ -53,7 +54,7 @@ class GsonParser extends JsonParser {
 
   @Override
   public String getCurrentName() {
-    return currentNameStack.isEmpty() ? null : currentNameStack.get(currentNameStack.size() - 1);
+    return currentNameStack.isEmpty() ? null : currentNameStack.getLast();
   }
 
   @Override
@@ -158,7 +159,7 @@ class GsonParser extends JsonParser {
       case END_ARRAY:
         currentText = "]";
         currentToken = JsonToken.END_ARRAY;
-        currentNameStack.remove(currentNameStack.size() - 1);
+        currentNameStack.removeLast();
         reader.endArray();
         break;
       case BEGIN_OBJECT:
@@ -168,7 +169,7 @@ class GsonParser extends JsonParser {
       case END_OBJECT:
         currentText = "}";
         currentToken = JsonToken.END_OBJECT;
-        currentNameStack.remove(currentNameStack.size() - 1);
+        currentNameStack.removeLast();
         reader.endObject();
         break;
       case BOOLEAN:
@@ -199,7 +200,8 @@ class GsonParser extends JsonParser {
       case NAME:
         currentText = reader.nextName();
         currentToken = JsonToken.FIELD_NAME;
-        currentNameStack.set(currentNameStack.size() - 1, currentText);
+        currentNameStack.removeLast();
+        currentNameStack.add(currentText);
         break;
       default:
         currentText = null;

--- a/google-http-client/src/main/java/com/google/api/client/testing/http/javanet/MockHttpURLConnection.java
+++ b/google-http-client/src/main/java/com/google/api/client/testing/http/javanet/MockHttpURLConnection.java
@@ -141,7 +141,7 @@ public class MockHttpURLConnection extends HttpURLConnection {
     if (headers.containsKey(name)) {
       headers.get(name).add(value);
     } else {
-      List<String> values = new ArrayList<String>();
+      List<String> values = new LinkedList<String>();
       values.add(value);
       headers.put(name, values);
     }

--- a/google-http-client/src/main/java/com/google/api/client/testing/http/javanet/MockHttpURLConnection.java
+++ b/google-http-client/src/main/java/com/google/api/client/testing/http/javanet/MockHttpURLConnection.java
@@ -24,6 +24,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.UnknownServiceException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/google-http-client/src/main/java/com/google/api/client/util/FieldInfo.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/FieldInfo.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -135,7 +136,7 @@ public class FieldInfo {
 
   /** Creates list of setter methods for a field only in declaring class. */
   private Method[] settersMethodForField(Field field) {
-    List<Method> methods = new ArrayList<>();
+    List<Method> methods = new LinkedList<>();
     for (Method method : field.getDeclaringClass().getDeclaredMethods()) {
       if (Ascii.toLowerCase(method.getName()).equals("set" + Ascii.toLowerCase(field.getName()))
           && method.getParameterTypes().length == 1) {

--- a/google-http-client/src/main/java/com/google/api/client/util/Types.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Types.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -122,7 +123,7 @@ public class Types {
       Exception e, Class<?> clazz) {
     StringBuilder buf =
         new StringBuilder("unable to create new instance of class ").append(clazz.getName());
-    ArrayList<String> reasons = new ArrayList<String>();
+    LinkedList<String> reasons = new LinkedList<String>();
     if (clazz.isArray()) {
       reasons.add("because it is an array");
     } else if (clazz.isPrimitive()) {


### PR DESCRIPTION
Hi,
We find that there are several ArrayList objects which are not manipulated by random access. Due to the memory reallocation triggered in the successive insertions, the time complexity of add method of ArrayList is amortized O(1). We notice that these objects are only used for traversal and the retrieval for the first or the last element. This functionality can be implemented by LinkedList. Moreover, the insertion of LinkedList is strictly O(1) time complexity because no memory reallocation occurs.

We discovered this inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto