### PR TITLE
GenericUrl: improve the error message for malformed URLs

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
@@ -676,7 +676,7 @@ public class GenericUrl extends GenericData {
     try {
       return new URL(encodedUrl);
     } catch (MalformedURLException e) {
-      throw new IllegalArgumentException(e);
+      throw new IllegalArgumentException("Malformed URL: \"" + encodedUrl + "\"", e);
     }
   }
 }

--- a/google-http-client/src/test/java/com/google/api/client/http/GenericUrlTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/GenericUrlTest.java
@@ -14,6 +14,9 @@
 
 package com.google.api.client.http;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import com.google.api.client.util.Key;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -96,6 +99,15 @@ public class GenericUrlTest extends TestCase {
     assertEquals("bar", url.getHost());
     assertEquals("b", url.getFirst("a"));
     assertNull(url.getPathParts());
+  }
+
+  public void testParse_malformedUrl() {
+    try {
+      new GenericUrl("http://example.com:8080http://example.com:8080/");
+      fail("expected " + IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), equalTo("Malformed URL: \"http://example.com:8080http://example.com:8080/\""));
+    }
   }
 
   private static final String SHORT_PATH = "http://bar/path?a=b";


### PR DESCRIPTION
Let's say by mistake we pass a malformed URL to the constructor of `GenericUrl`.

```java
new GenericUrl("http://example.com:8080http://example.com:8080");
```

Previously the line above used to throw the following exception:

```
java.lang.IllegalArgumentException: java.net.MalformedURLException: Error at index 4 in: "8080http:"
```

Not very helpful.

Whereas with this patch:

```java
java.lang.IllegalArgumentException: Malformed URL: "http://example.com:8080http://example.com:8080/"
```

The exception thrown now clearly shows what was the faulty URL.
The user can therefore quickly figure out which URL needs to be fixed.

A lesson I learned today :)