### PR TITLE
deps: update dependency com.google.code.gson:gson to v2.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,7 @@
     <project.appengine.version>1.9.71</project.appengine.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.jsr305.version>3.0.2</project.jsr305.version>
-    <project.gson.version>2.8.6</project.gson.version>
+    <project.gson.version>2.8.9</project.gson.version>
     <project.jackson-core2.version>2.12.2</project.jackson-core2.version>
     <project.protobuf-java.version>3.15.8</project.protobuf-java.version>
     <project.guava.version>30.1.1-android</project.guava.version>


### PR DESCRIPTION
There is a [vulnerability](https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327) in the gson library <=2.2.8, which has been fixed in 2.8.9