### PR TITLE
chore: downstream check for all libraries in single job

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -1,3 +1,3 @@
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-java:latest
-  digest: sha256:491a007c6bd6e77f9e9b1bebcd6cdf08a4a4ef2c228c123d9696845204cb685d
+  digest: sha256:3c950ed12391ebaffd1ee66d0374766a1c50144ebe6a7a0042300b2e6bb5856b

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ If you are still having issues, please include as much information as possible:
    General, Core, and Other are also allowed as types
 2. OS type and version:
 3. Java version:
-4. google-http-client version(s):
+4.  version(s):
 
 #### Steps to reproduce
 

--- a/.github/workflows/approve-readme.yaml
+++ b/.github/workflows/approve-readme.yaml
@@ -1,3 +1,18 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Github action job to test core java library features on
+# downstream client libraries before they are released.
 on:
   pull_request:
 name: auto-merge-readme
@@ -6,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'googleapis' && github.head_ref == 'autosynth-readme'
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v5
         with:
           github-token: ${{secrets.YOSHI_APPROVER_TOKEN}}
           script: |

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -1,3 +1,18 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Github action job to test core java library features on
+# downstream client libraries before they are released.
 on:
   pull_request:
 name: auto-release
@@ -6,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.head_ref, 'release-please')
     steps:
-    - uses: actions/github-script@v3
+    - uses: actions/github-script@v5
       with:
         github-token: ${{secrets.YOSHI_APPROVER_TOKEN}}
         debug: true
@@ -16,13 +31,13 @@ jobs:
             return;
           }
 
-          // only approve PRs like "chore: release <release version>"
-          if ( !context.payload.pull_request.title.startsWith("chore: release") ) {
+          // only approve PRs like "chore(main): release <release version>"
+          if (  !context.payload.pull_request.title.startsWith("chore(main): release") ) {
             return;
           }
 
           // only approve PRs with pom.xml and versions.txt changes
-          const filesPromise = github.pulls.listFiles.endpoint({
+          const filesPromise = github.rest.pulls.listFiles.endpoint({
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: context.payload.pull_request.number,
@@ -54,7 +69,7 @@ jobs:
             return;
           }
 
-          const promise = github.pulls.list.endpoint({
+          const promise = github.rest.pulls.list.endpoint({
             owner: context.repo.owner,
             repo: context.repo.repo,
             state: 'open'
@@ -71,7 +86,7 @@ jobs:
           }
 
           // approve release PR
-          await github.pulls.createReview({
+          await github.rest.pulls.createReview({
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: 'Rubber stamped release!',
@@ -80,7 +95,7 @@ jobs:
           });
 
           // attach kokoro:force-run and automerge labels
-          await github.issues.addLabels({
+          await github.rest.issues.addLabels({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.payload.pull_request.number,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,18 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Github action job to test core java library features on
+# downstream client libraries before they are released.
 on:
   push:
     branches:

--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         java: [8]
         repo:
+        # This list needs to be updated manually until an automated solution is in place.
         - accessapproval
         - accesscontextmanager
         - aiplatform

--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17]
+        java: [8]
         repo:
         - accessapproval
         - accesscontextmanager

--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -1,0 +1,141 @@
+on:
+  pull_request:
+    types: [ labeled ]
+    branches:
+    - main
+name: downstream
+jobs:
+  dependencies:
+    if: ${{ github.event.label.name == 'downstream-check:run' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [17]
+        repo:
+        - accessapproval
+        - accesscontextmanager
+        - aiplatform
+        - analytics-admin
+        - analytics-data
+        - api-gateway
+        - apigee-connect
+        - appengine-admin
+        - area120-tables
+        - artifact-registry
+        - asset
+        - assured-workloads
+        - automl
+        - bigquery
+        - bigqueryconnection
+        - bigquerydatatransfer
+        - bigquerymigration
+        - bigqueryreservation
+        - bigtable
+        - billing
+        - billingbudgets
+        - binary-authorization
+        - channel
+        - cloudbuild
+        - compute
+        - contact-center-insights
+        - container
+        - containeranalysis
+        - data-fusion
+        - datacatalog
+        - dataflow
+        - datalabeling
+        - dataproc
+        - dataproc-metastore
+        - datastore
+        - datastream
+        - debugger-client
+        - deploy
+        - dialogflow
+        - dialogflow-cx
+        - dlp
+        - dms
+        - dns
+        - document-ai
+        - domains
+        - errorreporting
+        - essential-contacts
+        - eventarc
+        - filestore
+        - firestore
+        - functions
+        - game-servers
+        - gke-connect-gateway
+        - gkehub
+        - gsuite-addons
+        - iam-admin
+        - iamcredentials
+        - iot
+        - kms
+        - language
+        - life-sciences
+        - logging
+        - logging-logback
+        - managed-identities
+        - mediatranslation
+        - memcache
+        - monitoring
+        - monitoring-dashboards
+        - network-management
+        - network-security
+        - networkconnectivity
+        - notebooks
+        - orchestration-airflow
+        - orgpolicy
+        - os-config
+        - os-login
+        - phishingprotection
+        - policy-troubleshooter
+        - private-catalog
+        - profiler
+        - pubsublite
+        - recaptchaenterprise
+        - recommendations-ai
+        - recommender
+        - redis
+        - resource-settings
+        - resourcemanager
+        - retail
+        - scheduler
+        - secretmanager
+        - security-private-ca
+        - securitycenter
+        - securitycenter-settings
+        - service-control
+        - service-management
+        - service-usage
+        - servicedirectory
+        - shell
+        - spanner
+        - spanner-jdbc
+        - speech
+        - storage
+        - storage-nio
+        - storage-transfer
+        - talent
+        - tasks
+        - texttospeech
+        - tpu
+        - trace
+        - translate
+        - video-intelligence
+        - video-transcoder
+        - vision
+        - vpcaccess
+        - webrisk
+        - websecurityscanner
+        - workflow-executions
+        - workflows
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: ${{matrix.java}}
+    - run: java -version
+    - run: sudo apt-get install libxml2-utils
+    - run: .kokoro/downstream-client-library-check.sh google-http-client-bom ${{matrix.repo}}

--- a/.kokoro/build.bat
+++ b/.kokoro/build.bat
@@ -1,3 +1,18 @@
 :: See documentation in type-shell-output.bat
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Github action job to test core java library features on
+# downstream client libraries before they are released.
 
 "C:\Program Files\Git\bin\bash.exe" %~dp0build.sh

--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+# Display commands being run.
+set -x
+
+
+CORE_LIBRARY_ARTIFACT=$1
+CLIENT_LIBRARY=$2
+## Get the directory of the build script
+scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+## cd to the parent directory, i.e. the root of the git repo
+cd ${scriptDir}/..
+
+# Make java core library artifacts available for 'mvn validate' at the bottom
+mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V -q
+
+# Read the current version of this java core library in the POM. Example version: '0.116.1-alpha-SNAPSHOT'
+CORE_VERSION_POM=pom.xml
+# Namespace (xmlns) prevents xmllint from specifying tag names in XPath
+CORE_VERSION=`sed -e 's/xmlns=".*"//' ${CORE_VERSION_POM} | xmllint --xpath '/project/version/text()' -`
+
+if [ -z "${CORE_VERSION}" ]; then
+  echo "Version is not found in ${CORE_VERSION_POM}"
+  exit 1
+fi
+echo "Version: ${CORE_VERSION}"
+
+# Round 1
+# Check this java core library against HEAD of java-shared dependencies
+
+git clone "https://github.com/googleapis/java-shared-dependencies.git" --depth=1
+pushd java-shared-dependencies/first-party-dependencies
+
+# replace version
+xmllint --shell <(cat pom.xml) << EOF
+setns x=http://maven.apache.org/POM/4.0.0
+cd .//x:artifactId[text()="${CORE_LIBRARY_ARTIFACT}"]
+cd ../x:version
+set ${CORE_VERSION}
+save pom.xml
+EOF
+
+# run dependencies script
+cd ..
+mvn -Denforcer.skip=true clean install
+
+SHARED_DEPS_VERSION_POM=pom.xml
+# Namespace (xmlns) prevents xmllint from specifying tag names in XPath
+SHARED_DEPS_VERSION=`sed -e 's/xmlns=".*"//' ${SHARED_DEPS_VERSION_POM} | xmllint --xpath '/project/version/text()' -`
+
+if [ -z "${SHARED_DEPS_VERSION}" ]; then
+  echo "Version is not found in ${SHARED_DEPS_VERSION_POM}"
+  exit 1
+fi
+
+# Round 2
+
+# Check this BOM against java client libraries
+git clone "https://github.com/googleapis/java-${CLIENT_LIBRARY}.git" --depth=1
+pushd java-${CLIENT_LIBRARY}
+
+if [[ $CLIENT_LIBRARY == "bigtable" ]]; then
+  pushd google-cloud-bigtable-deps-bom
+fi
+
+# replace version
+xmllint --shell <(cat pom.xml) << EOF
+setns x=http://maven.apache.org/POM/4.0.0
+cd .//x:artifactId[text()="google-cloud-shared-dependencies"]
+cd ../x:version
+set ${SHARED_DEPS_VERSION}
+save pom.xml
+EOF
+
+if [[ $CLIENT_LIBRARY == "bigtable" ]]; then
+  popd
+fi
+
+mvn -Denforcer.skip=true clean install

--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -25,7 +25,7 @@ scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 ## cd to the parent directory, i.e. the root of the git repo
 cd ${scriptDir}/..
 
-# Make java core library artifacts available for 'mvn validate' at the bottom
+# Make java core library artifacts available for 'mvn verify' at the bottom
 mvn verify install -B -V -ntp -fae \
 -DskipTests=true \
 -Dmaven.javadoc.skip=true \

--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -21,9 +21,9 @@ set -x
 CORE_LIBRARY_ARTIFACT=$1
 CLIENT_LIBRARY=$2
 ## Get the directory of the build script
-scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+scriptDir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 ## cd to the parent directory, i.e. the root of the git repo
-cd ${scriptDir}/..
+cd "${scriptDir}"/..
 
 # Make java core library artifacts available for 'mvn verify' at the bottom
 mvn verify install -B -V -ntp -fae \
@@ -35,7 +35,7 @@ mvn verify install -B -V -ntp -fae \
 # Read the current version of this java core library in the POM. Example version: '0.116.1-alpha-SNAPSHOT'
 CORE_VERSION_POM=pom.xml
 # Namespace (xmlns) prevents xmllint from specifying tag names in XPath
-CORE_VERSION=`sed -e 's/xmlns=".*"//' ${CORE_VERSION_POM} | xmllint --xpath '/project/version/text()' -`
+CORE_VERSION=$(sed -e 's/xmlns=".*"//' ${CORE_VERSION_POM} | xmllint --xpath '/project/version/text()' -)
 
 if [ -z "${CORE_VERSION}" ]; then
   echo "Version is not found in ${CORE_VERSION_POM}"
@@ -68,7 +68,7 @@ mvn verify install -B -V -ntp -fae \
 
 SHARED_DEPS_VERSION_POM=pom.xml
 # Namespace (xmlns) prevents xmllint from specifying tag names in XPath
-SHARED_DEPS_VERSION=`sed -e 's/xmlns=".*"//' ${SHARED_DEPS_VERSION_POM} | xmllint --xpath '/project/version/text()' -`
+SHARED_DEPS_VERSION=$(sed -e 's/xmlns=".*"//' ${SHARED_DEPS_VERSION_POM} | xmllint --xpath '/project/version/text()' -)
 
 if [ -z "${SHARED_DEPS_VERSION}" ]; then
   echo "Version is not found in ${SHARED_DEPS_VERSION_POM}"
@@ -79,7 +79,7 @@ fi
 
 # Check this BOM against java client libraries
 git clone "https://github.com/googleapis/java-${CLIENT_LIBRARY}.git" --depth=1
-pushd java-${CLIENT_LIBRARY}
+pushd java-"${CLIENT_LIBRARY}"
 
 if [[ $CLIENT_LIBRARY == "bigtable" ]]; then
   pushd google-cloud-bigtable-deps-bom

--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -29,7 +29,8 @@ cd ${scriptDir}/..
 mvn verify install -B -V -ntp -fae \
 -DskipTests=true \
 -Dmaven.javadoc.skip=true \
--Dgcloud.download.skip=true
+-Dgcloud.download.skip=true \
+-Denforcer.skip=true
 
 # Read the current version of this java core library in the POM. Example version: '0.116.1-alpha-SNAPSHOT'
 CORE_VERSION_POM=pom.xml
@@ -62,7 +63,8 @@ cd ..
 mvn verify install -B -V -ntp -fae \
 -DskipTests=true \
 -Dmaven.javadoc.skip=true \
--Dgcloud.download.skip=true
+-Dgcloud.download.skip=true \
+-Denforcer.skip=true
 
 SHARED_DEPS_VERSION_POM=pom.xml
 # Namespace (xmlns) prevents xmllint from specifying tag names in XPath
@@ -98,4 +100,5 @@ fi
 
 mvn verify install -B -V -ntp -fae \
 -Dmaven.javadoc.skip=true \
--Dgcloud.download.skip=true
+-Dgcloud.download.skip=true \
+-Denforcer.skip=true

--- a/.kokoro/downstream-client-library-check.sh
+++ b/.kokoro/downstream-client-library-check.sh
@@ -26,7 +26,10 @@ scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 cd ${scriptDir}/..
 
 # Make java core library artifacts available for 'mvn validate' at the bottom
-mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V -q
+mvn verify install -B -V -ntp -fae \
+-DskipTests=true \
+-Dmaven.javadoc.skip=true \
+-Dgcloud.download.skip=true
 
 # Read the current version of this java core library in the POM. Example version: '0.116.1-alpha-SNAPSHOT'
 CORE_VERSION_POM=pom.xml
@@ -56,7 +59,10 @@ EOF
 
 # run dependencies script
 cd ..
-mvn -Denforcer.skip=true clean install
+mvn verify install -B -V -ntp -fae \
+-DskipTests=true \
+-Dmaven.javadoc.skip=true \
+-Dgcloud.download.skip=true
 
 SHARED_DEPS_VERSION_POM=pom.xml
 # Namespace (xmlns) prevents xmllint from specifying tag names in XPath
@@ -90,4 +96,6 @@ if [[ $CLIENT_LIBRARY == "bigtable" ]]; then
   popd
 fi
 
-mvn -Denforcer.skip=true clean install
+mvn verify install -B -V -ntp -fae \
+-Dmaven.javadoc.skip=true \
+-Dgcloud.download.skip=true

--- a/.kokoro/nightly/java11-integration.cfg
+++ b/.kokoro/nightly/java11-integration.cfg
@@ -1,0 +1,37 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-public-resources/java11014"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "integration"
+}
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "ENABLE_FLAKYBOT"
+  value: "true"
+}
+
+env_vars: {
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-it-service-account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-it-service-account"
+}

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ might result, and you are not guaranteed a compilation error.
 [ci-status-link]: https://github.com/googleapis/google-http-java-client/actions?query=event%3Apush
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.http-client/google-http-client.svg
 [maven-version-link]: https://search.maven.org/search?q=g:com.google.http-client%20AND%20a:google-http-client&core=gav
-[stability-image]: https://img.shields.io/badge/stability-ga-green
+[stability-image]: https://img.shields.io/badge/stability-stable-green


### PR DESCRIPTION
Test core java libraries in java client libraries before release. Feature/code changes introduced in each PR can be tested on downstream java client libraries by adding `downstream-check:run` label. For now, unit tests are being run.

Next phase involves running samples and integration tests.

Note: Some of these tests are expected to fail due to individual client library conditions and do block the merging of this PR.