### PR TITLE
chore(docs): libraries-bom 24.3.0 in google-http-java-client

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,7 +23,7 @@ the `dependencyManagement` section of your `pom.xml`:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>24.1.1</version>
+      <version>24.3.0</version>
       <type>pom</type>
       <scope>import</scope>
      </dependency>


### PR DESCRIPTION
Libraries BOM 24.3.0 release documentation update in google-http-java-client repository.