### PR TITLE
ci: not requiring lint until Owlbot migration finishes

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -13,7 +13,6 @@ branchProtectionRules:
       - windows
       - dependencies (8)
       - dependencies (11)
-      - lint
       - clirr
       - cla/google
   - pattern: 1.39.2-sp


### PR DESCRIPTION
@Neenu1995 The check came back as "Required". I think we need to edit this file.