### PR TITLE
fix: add `@CanIgnoreReturnValue` to avoid errorprone errors.

### DIFF
--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -136,6 +136,10 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/google-http-client/src/main/java/com/google/api/client/util/SslUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/SslUtils.java
@@ -14,6 +14,7 @@
 
 package com.google.api.client.util;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
@@ -101,6 +102,7 @@ public final class SslUtils {
    *     #getPkixTrustManagerFactory()})
    * @since 1.14
    */
+  @CanIgnoreReturnValue
   public static SSLContext initSslContext(
       SSLContext sslContext, KeyStore trustStore, TrustManagerFactory trustManagerFactory)
       throws GeneralSecurityException {


### PR DESCRIPTION
In the monorepo, this blocks the build from succeeding.

Fixes #1710.