### PR TITLE
feat: GsonFactory to have read leniency option

### DIFF
--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
@@ -98,7 +98,7 @@ public class GsonFactory extends JsonFactory {
     return readLeniency;
   }
 
-  private GsonFactory createCopy() {
+  protected GsonFactory createCopy() {
     GsonFactory copy = new GsonFactory();
     copy.readLeniency = this.readLeniency;
     return copy;

--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
@@ -52,7 +52,8 @@ public class GsonFactory extends JsonFactory {
     return InstanceHolder.INSTANCE;
   }
 
-  private boolean readLeniency = false;
+  /** Controls the behavior of leniency in reading JSON value */
+  protected boolean readLeniency = false;
 
   /** Holder for the result of {@link #getDefaultInstance()}. */
   @Beta
@@ -104,7 +105,12 @@ public class GsonFactory extends JsonFactory {
     return copy;
   }
 
-  /** Returns a copy of GsonFactory instance which is lenient when reading JSON value. */
+  /**
+   * Returns a copy of GsonFactory instance which is lenient when reading JSON value.
+   *
+   * <p>Subclasses should not call this method. Set {@code readLeniency} field to {@code true}
+   * instead.
+   */
   public GsonFactory withReadLeniency() {
     GsonFactory copy = newInstance(this);
     copy.readLeniency = true;

--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
@@ -62,7 +62,7 @@ public class GsonFactory extends JsonFactory {
   }
 
   // Keeping the default, non-arg constructor for backward compatibility. Users should use
-  // getDefaultInstance() or builder()
+  // getDefaultInstance() or builder() instead.
   public GsonFactory() {}
 
   private GsonFactory(Builder builder) {
@@ -113,7 +113,7 @@ public class GsonFactory extends JsonFactory {
   }
 
   /** Builder for GsonFactory. */
-  public static class Builder {
+  public static final class Builder {
     // Do not directly call this constructor
     private Builder() {}
 

--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
@@ -52,6 +52,8 @@ public class GsonFactory extends JsonFactory {
     return InstanceHolder.INSTANCE;
   }
 
+  private boolean readLeniency = false;
+
   /** Holder for the result of {@link #getDefaultInstance()}. */
   @Beta
   static class InstanceHolder {
@@ -89,5 +91,17 @@ public class GsonFactory extends JsonFactory {
   @Override
   public JsonGenerator createJsonGenerator(Writer writer) {
     return new GsonGenerator(this, new JsonWriter(writer));
+  }
+
+  /** Returns true if it gives leniency to reading JSON value. */
+  boolean getReadLeniency() {
+    return readLeniency;
+  }
+
+  /** Returns copy of GsonFactory instance that is lenient when reading JSON value. */
+  public GsonFactory withReadLeniency() {
+    GsonFactory copy = new GsonFactory();
+    copy.readLeniency = true;
+    return copy;
   }
 }

--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
@@ -53,7 +53,7 @@ public class GsonFactory extends JsonFactory {
   }
 
   /** Controls the behavior of leniency in reading JSON value */
-  protected boolean readLeniency = false;
+  private boolean readLeniency = false;
 
   /** Holder for the result of {@link #getDefaultInstance()}. */
   @Beta
@@ -99,21 +99,32 @@ public class GsonFactory extends JsonFactory {
     return readLeniency;
   }
 
-  private static GsonFactory newInstance(GsonFactory gsonFactory) {
-    GsonFactory copy = new GsonFactory();
-    copy.readLeniency = gsonFactory.readLeniency;
-    return copy;
+  /** Returns the builder * */
+  public static Builder builder() {
+    return new Builder();
   }
 
-  /**
-   * Returns a copy of GsonFactory instance which is lenient when reading JSON value.
-   *
-   * <p>Subclasses should not call this method. Set {@code readLeniency} field to {@code true}
-   * instead.
-   */
-  public GsonFactory withReadLeniency() {
-    GsonFactory copy = newInstance(this);
-    copy.readLeniency = true;
-    return copy;
+  /** Builder for GsonFactory. */
+  public static class Builder {
+    // Do not directly call this constructor
+    private Builder() {}
+
+    private boolean readLeniency = false;
+
+    /**
+     * Set to {@code true} when you want to the JSON parser to be lenient to reading JSON value. By
+     * default, it is {@code false}.
+     */
+    public Builder setReadLeniency(boolean readLeniency) {
+      this.readLeniency = readLeniency;
+      return this;
+    }
+
+    /** Builds GsonFactory instance. */
+    public GsonFactory build() {
+      GsonFactory instance = new GsonFactory();
+      instance.readLeniency = readLeniency;
+      return instance;
+    }
   }
 }

--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
@@ -61,6 +61,14 @@ public class GsonFactory extends JsonFactory {
     static final GsonFactory INSTANCE = new GsonFactory();
   }
 
+  // Keeping the default, non-arg constructor for backward compatibility. Users should use
+  // getDefaultInstance() or builder()
+  public GsonFactory() {}
+
+  private GsonFactory(Builder builder) {
+    readLeniency = builder.readLeniency;
+  }
+
   @Override
   public JsonParser createJsonParser(InputStream in) {
     return createJsonParser(new InputStreamReader(in, StandardCharsets.UTF_8));
@@ -122,9 +130,7 @@ public class GsonFactory extends JsonFactory {
 
     /** Builds GsonFactory instance. */
     public GsonFactory build() {
-      GsonFactory instance = new GsonFactory();
-      instance.readLeniency = readLeniency;
-      return instance;
+      return new GsonFactory(this);
     }
   }
 }

--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
@@ -98,15 +98,15 @@ public class GsonFactory extends JsonFactory {
     return readLeniency;
   }
 
-  protected GsonFactory createCopy() {
+  private static GsonFactory newInstance(GsonFactory gsonFactory) {
     GsonFactory copy = new GsonFactory();
-    copy.readLeniency = this.readLeniency;
+    copy.readLeniency = gsonFactory.readLeniency;
     return copy;
   }
 
   /** Returns a copy of GsonFactory instance which is lenient when reading JSON value. */
   public GsonFactory withReadLeniency() {
-    GsonFactory copy = createCopy();
+    GsonFactory copy = newInstance(this);
     copy.readLeniency = true;
     return copy;
   }

--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonFactory.java
@@ -93,14 +93,20 @@ public class GsonFactory extends JsonFactory {
     return new GsonGenerator(this, new JsonWriter(writer));
   }
 
-  /** Returns true if it gives leniency to reading JSON value. */
+  /** Returns true if it is lenient to input JSON value. */
   boolean getReadLeniency() {
     return readLeniency;
   }
 
-  /** Returns copy of GsonFactory instance that is lenient when reading JSON value. */
-  public GsonFactory withReadLeniency() {
+  private GsonFactory createCopy() {
     GsonFactory copy = new GsonFactory();
+    copy.readLeniency = this.readLeniency;
+    return copy;
+  }
+
+  /** Returns a copy of GsonFactory instance which is lenient when reading JSON value. */
+  public GsonFactory withReadLeniency() {
+    GsonFactory copy = createCopy();
     copy.readLeniency = true;
     return copy;
   }

--- a/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonParser.java
+++ b/google-http-client-gson/src/main/java/com/google/api/client/json/gson/GsonParser.java
@@ -43,7 +43,7 @@ class GsonParser extends JsonParser {
   GsonParser(GsonFactory factory, JsonReader reader) {
     this.factory = factory;
     this.reader = reader;
-    reader.setLenient(false);
+    reader.setLenient(factory.getReadLeniency());
   }
 
   @Override

--- a/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonFactoryTest.java
+++ b/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonFactoryTest.java
@@ -14,10 +14,16 @@
 
 package com.google.api.client.json.gson;
 
+import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.json.JsonParser;
 import com.google.api.client.test.json.AbstractJsonFactoryTest;
+import com.google.gson.stream.MalformedJsonException;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 /**
@@ -91,6 +97,32 @@ public class GsonFactoryTest extends AbstractJsonFactoryTest {
       parser.getByteValue();
       fail("should throw IOException");
     } catch (IOException ex) {
+      assertNotNull(ex.getMessage());
+    }
+  }
+
+  public final void testReaderLeniency_lenient() throws IOException {
+    JsonObjectParser parser =
+        new JsonObjectParser(GsonFactory.getDefaultInstance().withReadLeniency());
+
+    // This prefix in JSON body is used to prevent Cross-site script inclusion (XSSI).
+    InputStream inputStream =
+        new ByteArrayInputStream((")]}'\n" + JSON_ENTRY_PRETTY).getBytes(StandardCharsets.UTF_8));
+    GenericJson json = parser.parseAndClose(inputStream, StandardCharsets.UTF_8, GenericJson.class);
+
+    assertEquals("foo", json.get("title"));
+  }
+
+  public final void testReaderLeniency_not_lenient() throws IOException {
+    JsonObjectParser parser = new JsonObjectParser(GsonFactory.getDefaultInstance());
+
+    try {
+      // This prefix in JSON body is used to prevent Cross-site script inclusion (XSSI).
+      InputStream inputStream =
+          new ByteArrayInputStream((")]}'\n" + JSON_ENTRY_PRETTY).getBytes(StandardCharsets.UTF_8));
+      parser.parseAndClose(inputStream, StandardCharsets.UTF_8, GenericJson.class);
+      fail("The read leniency should fail the malformed JSON input.");
+    } catch (MalformedJsonException ex) {
       assertNotNull(ex.getMessage());
     }
   }

--- a/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonFactoryTest.java
+++ b/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonFactoryTest.java
@@ -103,7 +103,7 @@ public class GsonFactoryTest extends AbstractJsonFactoryTest {
 
   public final void testReaderLeniency_lenient() throws IOException {
     JsonObjectParser parser =
-        new JsonObjectParser(GsonFactory.getDefaultInstance().withReadLeniency());
+        new JsonObjectParser(GsonFactory.builder().setReadLeniency(true).build());
 
     // This prefix in JSON body is used to prevent Cross-site script inclusion (XSSI).
     InputStream inputStream =
@@ -121,7 +121,7 @@ public class GsonFactoryTest extends AbstractJsonFactoryTest {
       InputStream inputStream =
           new ByteArrayInputStream((")]}'\n" + JSON_ENTRY_PRETTY).getBytes(StandardCharsets.UTF_8));
       parser.parseAndClose(inputStream, StandardCharsets.UTF_8, GenericJson.class);
-      fail("The read leniency should fail the malformed JSON input.");
+      fail("The read leniency should fail the JSON input with XSSI prefix.");
     } catch (MalformedJsonException ex) {
       assertNotNull(ex.getMessage());
     }

--- a/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonFactoryTest.java
+++ b/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonFactoryTest.java
@@ -113,7 +113,7 @@ public class GsonFactoryTest extends AbstractJsonFactoryTest {
     assertEquals("foo", json.get("title"));
   }
 
-  public final void testReaderLeniency_not_lenient() throws IOException {
+  public final void testReaderLeniency_not_lenient_by_default() throws IOException {
     JsonObjectParser parser = new JsonObjectParser(GsonFactory.getDefaultInstance());
 
     try {

--- a/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonParserTest.java
+++ b/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonParserTest.java
@@ -13,13 +13,30 @@
  */
 package com.google.api.client.json.gson;
 
+import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.test.json.AbstractJsonParserTest;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 
 public class GsonParserTest extends AbstractJsonParserTest {
 
   @Override
   protected JsonFactory newJsonFactory() {
     return new GsonFactory();
+  }
+
+  public void testParse_leniency() throws IOException {
+    GsonFactory factory = GsonFactory.getDefaultInstance();
+    JsonObjectParser parser = new JsonObjectParser(factory);
+    InputStream inputStream =
+        new ByteArrayInputStream(
+            ")]}'\n{\"bigDecimalValue\": 1559341956102}".getBytes(StandardCharsets.UTF_8));
+    GenericJson json = parser.parseAndClose(inputStream, StandardCharsets.UTF_8, GenericJson.class);
+    assertEquals(new BigDecimal("1559341956102"), json.get("bigDecimalValue"));
   }
 }

--- a/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonParserTest.java
+++ b/google-http-client-gson/src/test/java/com/google/api/client/json/gson/GsonParserTest.java
@@ -13,30 +13,13 @@
  */
 package com.google.api.client.json.gson;
 
-import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.test.json.AbstractJsonParserTest;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
 
 public class GsonParserTest extends AbstractJsonParserTest {
 
   @Override
   protected JsonFactory newJsonFactory() {
     return new GsonFactory();
-  }
-
-  public void testParse_leniency() throws IOException {
-    GsonFactory factory = GsonFactory.getDefaultInstance();
-    JsonObjectParser parser = new JsonObjectParser(factory);
-    InputStream inputStream =
-        new ByteArrayInputStream(
-            ")]}'\n{\"bigDecimalValue\": 1559341956102}".getBytes(StandardCharsets.UTF_8));
-    GenericJson json = parser.parseAndClose(inputStream, StandardCharsets.UTF_8, GenericJson.class);
-    assertEquals(new BigDecimal("1559341956102"), json.get("bigDecimalValue"));
   }
 }


### PR DESCRIPTION
Fixes b/269515918, where the prefix `)]}'\n` for Cross-site script inclusion (XSSI) didn't work for GsonFactory.

Users will call `GsonFactory.getDefaultInstance().withReadLeniency()` when they want this library to process JSON input that may have the prefix.

- For this pull request, it controlls only the leniency when reading input JSON. This design `withReadLeniency()` gives flexibility for us to choose writeLeniency in future if necessary. (It's possible that read leniency is true and write leniency is false.)
- Because this creates a copy of the instance, it does not affect existing usage of GsonFactory. (No global state in GsonFactory)
