### PR TITLE
ci: fmt-maven-plugin 2.9 with google-java-format 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -542,10 +542,18 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.13</version>
+        <version>2.9</version>
         <configuration>
+          <style>google</style>
           <verbose>true</verbose>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.google.googlejavaformat</groupId>
+            <artifactId>google-java-format</artifactId>
+            <version>1.7</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This matches OwlBot Java post procesosr
https://github.com/googleapis/synthtool/blob/5f2a6089f73abf06238fe4310f6a14d6f6d1eed3/docker/owlbot/java/Dockerfile#L22

Downgrading fmt-maven-plugin to 2.9 because the new one does not run with Java 8.
