### PR TITLE
javanet: Add ProxySelector support

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/javanet/DefaultConnectionFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/javanet/DefaultConnectionFactory.java
@@ -3,6 +3,8 @@ package com.google.api.client.http.javanet;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 /**
@@ -12,9 +14,10 @@ import java.net.URL;
 public class DefaultConnectionFactory implements ConnectionFactory {
 
   private final Proxy proxy;
+  private final ProxySelector proxySelector;
 
   public DefaultConnectionFactory() {
-    this(null);
+    this((Proxy)null);
   }
 
   /**
@@ -23,11 +26,27 @@ public class DefaultConnectionFactory implements ConnectionFactory {
    *     system properties</a>
    */
   public DefaultConnectionFactory(Proxy proxy) {
+    this(proxy, null);
+  }
+
+  public DefaultConnectionFactory(ProxySelector proxySelector) {
+    this(null, proxySelector);
+  }
+
+  public DefaultConnectionFactory(Proxy proxy, ProxySelector proxySelector) {
     this.proxy = proxy;
+    this.proxySelector = proxySelector;
   }
 
   @Override
   public HttpURLConnection openConnection(URL url) throws IOException {
+    Proxy proxy = this.proxy;
+    if(proxySelector != null) {
+      try {
+        proxy = proxySelector.select(url.toURI()).get(0);
+      } catch (URISyntaxException e) {
+      }
+    }
     return (HttpURLConnection) (proxy == null ? url.openConnection() : url.openConnection(proxy));
   }
 }

--- a/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpTransport.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpTransport.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.net.ProxySelector;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
@@ -80,6 +81,7 @@ public final class NetHttpTransport extends HttpTransport {
   }
 
   private static final String SHOULD_USE_PROXY_FLAG = "com.google.api.client.should_use_proxy";
+  private static final String SHOULD_USE_PROXY_SELECTOR_FLAG = "com.google.api.client.should_use_proxy_selector";
 
   private final ConnectionFactory connectionFactory;
 
@@ -141,6 +143,8 @@ public final class NetHttpTransport extends HttpTransport {
     if (connectionFactory == null) {
       if (System.getProperty(SHOULD_USE_PROXY_FLAG) != null) {
         return new DefaultConnectionFactory(defaultProxy());
+      } else if(System.getProperty(SHOULD_USE_PROXY_SELECTOR_FLAG) != null) {
+          return new DefaultConnectionFactory(ProxySelector.getDefault());
       }
       return new DefaultConnectionFactory();
     }


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-http-java-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Add ProxySelector support for javanet client.

com.google.auth.oauth2.OAuth2Utils.HTTP_TRANSPORT uses javanet client by default, the added ProxySelector support makes it a bit easier to control what HTTP connections should use a proxy or none.

Fixes https://github.com/googleapis/google-auth-library-java/issues/1180
