### PR TITLE
deps: testing exlcusing commons-logging

### DIFF
--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -126,6 +126,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
List of classes that use commons-logging in `org:apache:httpcomponents:httpclient`:

<img width="795" alt="Screenshot 2024-01-23 at 11 51 25 AM" src="https://github.com/googleapis/google-http-java-client/assets/28604/448d3e31-1f16-4a26-b20e-c7e9284f8d65">

List of classes that use `org:apache:httpcomponents:httpclient` in google-http-java-client:
<img width="756" alt="Screenshot 2024-01-23 at 11 52 50 AM" src="https://github.com/googleapis/google-http-java-client/assets/28604/9ae746af-6749-43c3-a872-45102312a1eb">

Fortunately there's no overlap. Indeed the tests pass.
