### PR TITLE
chore: Update owlbot.py to exclude `ci.yaml`

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -28,6 +28,7 @@ java.common_templates(
         "checkstyle.xml",
         "license-checks.xml",
         ".github/workflows/samples.yaml",
-        ".kokoro/build.sh"
+        ".kokoro/build.sh",
+        ".github/workflows/ci.yaml"
     ]
 )


### PR DESCRIPTION
Need owlbot to ignore `ci.yaml` so that changes in https://github.com/googleapis/google-http-java-client/pull/1907 can persist.

