### PR TITLE
chore: troubleshooting build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -367,7 +367,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.4.5</version>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -377,7 +377,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.4.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -387,7 +387,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.1.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -395,7 +395,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.4.1</version><executions>
+        <version>3.1.0</version><executions>
         <execution>
           <id>enforce-maven</id>
           <goals>
@@ -537,7 +537,7 @@
       <!-- Build the dependencies report at package time (needed for the assembly artifact). -->
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.4.5</version>
+        <version>3.4.1</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -89,12 +89,13 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <!-- Troubleshooting build failure
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>native-image-shared-config</artifactId>
     <version>1.7.1</version>
   </parent>
-
+  -->
   <!--
     If you change the version of a dependency, make sure to update the javadoc
     links if required, and any javadoc links of your dependency in the oauth and


### PR DESCRIPTION
Troubleshooting the failure https://github.com/googleapis/google-http-java-client/pull/1872#issuecomment-1908864007

That release and the main branch fail:

```
[INFO] --- maven-source-plugin:3.3.0:jar-no-fork (attach-sources) @ google-http-client ---
[ERROR] We have duplicated artifacts attached.
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-source-plugin:3.3.0:jar-no-fork (attach-sources) on project google-http-client: Presumably you have configured maven-source-plugn to execute twice times in your build. You have to configure a classifier for at least on of them. -> [Help 1]
```

