### PR TITLE
chore: fix renovate bot settings for native-image-shared-config pom update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,7 @@
         "^org.codehaus.mojo:",
         "^org.sonatype.plugins:",
         "^com.coveo:",
-        "^com.google.cloud:google-cloud-shared-config"
+        "^com.google.cloud:native-image-shared-config"
       ],
       "semanticCommitType": "build",
       "semanticCommitScope": "deps"

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
+    "config:recommended",
     ":separateMajorReleases",
     ":combinePatchMinorReleases",
     ":ignoreUnstable",
@@ -49,7 +50,8 @@
         "^com.google.cloud:native-image-shared-config"
       ],
       "semanticCommitType": "build",
-      "semanticCommitScope": "deps"
+      "semanticCommitScope": "deps",
+      "enabled": true
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
For #1964 

This PR:
- Corrects the config to update `native-image-shared-config` in the POM.
- Emulate config settings in sdk-platform-java's [renovate.json](https://github.com/googleapis/sdk-platform-java/blob/main/renovate.json)