### PR TITLE
chore: Limit guava version to v30

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,8 @@
       "matchPackagePatterns": [
         "^com.google.guava:"
       ],
-      "versioning": "docker"
+      "versioning": "docker",
+      "allowedVersions": "<32.0.0"
     },
     {
       "matchPackagePatterns": [

--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,7 @@
         "^com.google.guava:"
       ],
       "versioning": "docker",
-      "allowedVersions": "<32.0.0-android"
+      "allowedVersions": "<31.0.0-android"
     },
     {
       "matchPackagePatterns": [

--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,7 @@
         "^com.google.guava:"
       ],
       "versioning": "docker",
-      "allowedVersions": "<32.0.0"
+      "allowedVersions": "<32.0.0-android"
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Guava v31+ seems to support Java 8+. Try to limit to Guava v30 and see if this resolves the renovate issue.