### PR TITLE
chore: add java 21 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -611,6 +611,43 @@
 
   <profiles>
     <profile>
+      <id>java21</id>
+      <activation>
+        <jdk>21</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.13.0</version>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.8.0</version>
+            <configuration>
+              <source>8</source>
+              <failOnError>false</failOnError>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>native-tests</id>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -613,7 +613,7 @@
     <profile>
       <id>java21</id>
       <activation>
-        <jdk>21</jdk>
+        <jdk>[21,)</jdk>
       </activation>
       <build>
         <plugins>
@@ -631,7 +631,7 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.8.0</version>
             <configuration>
-              <source>8</source>
+              <source>1.8</source>
               <failOnError>false</failOnError>
             </configuration>
             <executions>


### PR DESCRIPTION
As discovered in https://github.com/googleapis/google-http-java-client/pull/1975,  running `mvn clean install` in jdk 21 is results in the following error:
```
INFO] Compiling 157 source files with javac [debug target 1.7] to target/classes
[INFO] -------------------------------------------------------------
[WARNING] COMPILATION WARNING : 
[INFO] -------------------------------------------------------------
[WARNING] bootstrap class path not set in conjunction with -source 7
[INFO] 1 warning
[INFO] -------------------------------------------------------------
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] Source option 7 is no longer supported. Use 8 or later.
[ERROR] Target option 7 is no longer supported. Use 8 or later.
[INFO] 2 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Parent for the Google HTTP Client Library for Java 1.44.3-SNAPSHOT:
```

This is because the parent pom explicitly sets the [source/target values in the maven-compiler-plugin](https://github.com/googleapis/google-http-java-client/blob/8c95cbe3d0f435666f5fd0feb9a6bef8762a0af6/pom.xml#L289-L293) and [maven-javadoc-plugin to 1.7](https://github.com/googleapis/google-http-java-client/blob/8c95cbe3d0f435666f5fd0feb9a6bef8762a0af6/pom.xml#L430-L436).  

This PR introduces a profile that is activated when jdk 21 is used and overrides the source/target values to 1.8 in the `maven-compiler-plugin` and `maven-javadoc-plugin`. 