### PR TITLE
chore: migrate graalvm jobs to kokoro instance pool

### DIFF
--- a/.kokoro/presubmit/common.cfg
+++ b/.kokoro/presubmit/common.cfg
@@ -23,12 +23,3 @@ env_vars: {
   key: "JOB_TYPE"
   value: "test"
 }
-
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "dpebot_codecov_token"
-    }
-  }
-}

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -1,14 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
-<<<<<<< Updated upstream
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_a:1.11.3"
-}
-=======
->>>>>>> Stashed changes
-
 env_vars: {
   key: "JOB_TYPE"
   value: "graalvmA"

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -27,5 +27,5 @@ env_vars: {
 }
 
 container_properties {
-  docker_image: "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_a:1.11.3"
+  docker_image: "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_a:1.12.0"
 }

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -1,5 +1,7 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
+build_file: "google-http-java-client/.kokoro/build.sh"
+
 env_vars: {
   key: "JOB_TYPE"
   value: "graalvmA"

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -27,5 +27,5 @@ env_vars: {
 }
 
 container_properties {
-  docker_image: "gcr.io/cloud-devrel-public-resources/graalvm_a:1.11.3"
+  docker_image: "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_a:1.11.3"
 }

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -1,10 +1,13 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 # Configure the docker image for kokoro-trampoline.
+<<<<<<< Updated upstream
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
   value: "gcr.io/cloud-devrel-public-resources/graalvm_a:1.11.3"
 }
+=======
+>>>>>>> Stashed changes
 
 env_vars: {
   key: "JOB_TYPE"
@@ -30,4 +33,8 @@ env_vars: {
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "java-it-service-account"
+}
+
+container_properties {
+  docker_image: "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_a:1.11.3"
 }

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -27,5 +27,5 @@ env_vars: {
 }
 
 container_properties {
-  docker_image: "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_a:1.11.3"
+  docker_image: "gcr.io/cloud-devrel-public-resources/graalvm_a:1.11.3"
 }

--- a/.kokoro/presubmit/graalvm-native-b.cfg
+++ b/.kokoro/presubmit/graalvm-native-b.cfg
@@ -2,11 +2,14 @@
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
+<<<<<<< Updated upstream
   key: "TRAMPOLINE_IMAGE"
   value: "gcr.io/cloud-devrel-public-resources/graalvm_b:1.11.3"
 }
 
 env_vars: {
+=======
+>>>>>>> Stashed changes
   key: "JOB_TYPE"
   value: "graalvmB"
 }
@@ -31,3 +34,10 @@ env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "java-it-service-account"
 }
+<<<<<<< Updated upstream
+=======
+
+container_properties {
+  docker_image: "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_b:1.11.3"
+}
+>>>>>>> Stashed changes

--- a/.kokoro/presubmit/graalvm-native-b.cfg
+++ b/.kokoro/presubmit/graalvm-native-b.cfg
@@ -27,5 +27,5 @@ env_vars: {
 }
 
 container_properties {
-  docker_image: "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_b:1.11.3"
+  docker_image: "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_b:1.12.0"
 }

--- a/.kokoro/presubmit/graalvm-native-b.cfg
+++ b/.kokoro/presubmit/graalvm-native-b.cfg
@@ -1,5 +1,7 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
+build_file: "google-http-java-client/.kokoro/build.sh"
+
 env_vars: {
   key: "JOB_TYPE"
   value: "graalvmB"

--- a/.kokoro/presubmit/graalvm-native-b.cfg
+++ b/.kokoro/presubmit/graalvm-native-b.cfg
@@ -1,15 +1,6 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
 env_vars: {
-<<<<<<< Updated upstream
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_b:1.11.3"
-}
-
-env_vars: {
-=======
->>>>>>> Stashed changes
   key: "JOB_TYPE"
   value: "graalvmB"
 }
@@ -34,10 +25,7 @@ env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "java-it-service-account"
 }
-<<<<<<< Updated upstream
-=======
 
 container_properties {
   docker_image: "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_b:1.11.3"
 }
->>>>>>> Stashed changes

--- a/renovate.json
+++ b/renovate.json
@@ -19,9 +19,13 @@
       "fileMatch": [
         "^.kokoro/presubmit/graalvm-native.*.cfg$"
       ],
+<<<<<<< Updated upstream
       "matchStrings": [
         "value: \"gcr.io/cloud-devrel-public-resources/graalvm.*:(?<currentValue>.*?)\""
       ],
+=======
+      "matchStrings": ["docker_image: \"us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm.*:(?<currentValue>.*?)\""],
+>>>>>>> Stashed changes
       "depNameTemplate": "com.google.cloud:native-image-shared-config",
       "datasourceTemplate": "maven"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -19,13 +19,7 @@
       "fileMatch": [
         "^.kokoro/presubmit/graalvm-native.*.cfg$"
       ],
-<<<<<<< Updated upstream
-      "matchStrings": [
-        "value: \"gcr.io/cloud-devrel-public-resources/graalvm.*:(?<currentValue>.*?)\""
-      ],
-=======
       "matchStrings": ["docker_image: \"us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm.*:(?<currentValue>.*?)\""],
->>>>>>> Stashed changes
       "depNameTemplate": "com.google.cloud:native-image-shared-config",
       "datasourceTemplate": "maven"
     }


### PR DESCRIPTION
Notable Changes:

- Removed unused keystore settings.
- Replaced use of TRAMPOLINE_IMAGE environment variable with `container_properties { docker_image ...}}`
- Modified renovate bot settings to edit new docker_image property's value when a new version of java-shared-config is available.