### PR TITLE
feat: support JDK 23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 17, 21]
+        java: [8, 11, 17, 23]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17]
+        java: [8, 11, 17, 23]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [8, 11, 17, 21]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4

--- a/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpTransportTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpTransportTest.java
@@ -204,7 +204,7 @@ public class NetHttpTransportTest extends TestCase {
             byte[] response = httpExchange.getRequestURI().toString().getBytes();
             httpExchange.sendResponseHeaders(200, response.length);
             try (OutputStream out = httpExchange.getResponseBody()) {
-              byte[] firstByte = new byte[] { 0x01 };
+              byte[] firstByte = new byte[] {0x01};
               out.write(firstByte);
               out.flush();
 

--- a/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpTransportTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpTransportTest.java
@@ -203,14 +203,17 @@ public class NetHttpTransportTest extends TestCase {
           public void handle(HttpExchange httpExchange) throws IOException {
             byte[] response = httpExchange.getRequestURI().toString().getBytes();
             httpExchange.sendResponseHeaders(200, response.length);
-
-            // Sleep for longer than the test timeout
-            try {
-              Thread.sleep(100_000);
-            } catch (InterruptedException e) {
-              throw new IOException("interrupted", e);
-            }
             try (OutputStream out = httpExchange.getResponseBody()) {
+              byte[] firstByte = new byte[] { 0x01 };
+              out.write(firstByte);
+              out.flush();
+
+              // Sleep for longer than the test timeout
+              try {
+                Thread.sleep(100_000);
+              } catch (InterruptedException e) {
+                throw new IOException("interrupted", e);
+              }
               out.write(response);
             }
           }


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-http-java-client/issues/2063
Thanks to @ldetmer and @burkedavison for the pointers on how to solve this.

The approach is to `flush()` a first byte in the test pointed out by the issue. That triggers sending the headers and unblocks `NetHttpResponse.<init>`