### PR TITLE
chore: add suppress warning for TrustAllX509TrustManager since that is what the method is actually supposed to do

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/SslUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/SslUtils.java
@@ -157,9 +157,11 @@ public final class SslUtils {
         new TrustManager[] {
           new X509TrustManager() {
 
+            @SuppressWarnings("TrustAllX509TrustManager")
             public void checkClientTrusted(X509Certificate[] chain, String authType)
                 throws CertificateException {}
 
+            @SuppressWarnings("TrustAllX509TrustManager")
             public void checkServerTrusted(X509Certificate[] chain, String authType)
                 throws CertificateException {}
 


### PR DESCRIPTION
This was flagged by android team as an issue when they take in our SDK

Fixes #[1866](https://github.com/googleapis/google-http-java-client/issues/1866)

