### PR TITLE
fix: encode plus sign in url with %2B

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/escape/PercentEscaper.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/escape/PercentEscaper.java
@@ -61,7 +61,7 @@ public class PercentEscaper extends UnicodeEscaper {
    * specified in RFC 3986. Note that some of these characters do need to be escaped when used in
    * other parts of the URI.
    */
-  public static final String SAFEPATHCHARS_URLENCODER = "-_.!~*'()@:$&,;=+";
+  public static final String SAFEPATHCHARS_URLENCODER = "-_.!~*'()@:$&,;=";
 
   /**
    * A string of characters that do not need to be encoded when used in URI Templates reserved
@@ -72,7 +72,7 @@ public class PercentEscaper extends UnicodeEscaper {
    * href="https://www.rfc-editor.org/rfc/rfc6570#section-3.2.3">RFC 6570 - section 3.2.3</a>.
    */
   public static final String SAFE_PLUS_RESERVED_CHARS_URLENCODER =
-      SAFEPATHCHARS_URLENCODER + "/?#[]";
+      SAFEPATHCHARS_URLENCODER + "+/?#[]";
 
   /**
    * A string of characters that do not need to be encoded when used in URI user info part, as

--- a/google-http-client/src/test/java/com/google/api/client/http/UrlEncodedContentTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/UrlEncodedContentTest.java
@@ -62,7 +62,7 @@ public class UrlEncodedContentTest {
     subtestWriteTo(
         "multi=a&multi=b&multi=c", ArrayMap.of("multi", new String[] {"a", "b", "c"}), true);
     subtestWriteTo("username=un&password=password123;%7B%7D", params, true);
-    subtestWriteTo("additionkey=add+tion", ArrayMap.of("additionkey", "add+tion"), true);
+    subtestWriteTo("additionkey=add%2Btion", ArrayMap.of("additionkey", "add+tion"), true);
   }
 
   private void subtestWriteTo(String expected, Object data, boolean useEscapeUriPathEncoding)


### PR DESCRIPTION
Currently we are not encoding + signs if it part of the URL path, while this [is to spec](https://www.rfc-editor.org/rfc/rfc1738.html)

Thus, only alphanumerics, the special characters "$-_.+!*'(),", and
   reserved characters used for their reserved purposes may be used
   unencoded within a URL.
 
It MAY be encoded.

Originally we did encode plus signs, but inappropriately as a space (%20).  This was fixed in this [PR](https://github.com/googleapis/google-http-java-client/pull/913) .  However the fix did 2 things, it stopped treating the + sign as a space, but it also stopped encoding it at all.  Technically it only need the first fix [here](https://github.com/googleapis/google-http-java-client/blob/main/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java#L591).  Removing encoding of the + sign caused several APIs to stop working (spreadsheets and gmail).

So this fix is to bring back converting + signs, however due to the original fix, it now converts them correctly to %2B (+), not %20 (space)

Note we still do NOT want + signs to be encoded for SAFEPATHCHARS_URLENCODER, as we still want to utilize it for [reserved expansions](https://www.rfc-editor.org/rfc/rfc6570#section-3.2.3) See [issue](https://github.com/googleapis/google-http-java-client/issues/1838)

Tested: gmail apiary, sheets apiary, storage apiary and gapic

Fixes #[20415](https://github.com/googleapis/google-api-java-client-services/issues/20415) 
Fixes #[1573](https://github.com/googleapis/google-http-java-client/issues/1573)



