### PR TITLE
chore: update ci tests to run against jdk 24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17, 23]
+        java: [8, 11, 17, 24]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 17, 23]
+        java: [8, 11, 17, 24]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4


### PR DESCRIPTION
this is order to support latest graalvm update