### PR TITLE
fix: add NULL_OBJECT to util.Data to work around Graal 24  issue

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/Data.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Data.java
@@ -91,6 +91,9 @@ public class Data {
   /** The single instance of the magic null object for a {@link DateTime}. */
   public static final DateTime NULL_DATE_TIME = new DateTime(0);
 
+  /** The single instance of the magic null object for a {@link Object}. */
+  public static final Object NULL_OBJECT = new Object();
+
   /** Cache of the magic null object for the given Java class. */
   private static final ConcurrentHashMap<Class<?>, Object> NULL_CACHE =
       new ConcurrentHashMap<Class<?>, Object>();
@@ -109,6 +112,7 @@ public class Data {
     NULL_CACHE.put(BigInteger.class, NULL_BIG_INTEGER);
     NULL_CACHE.put(BigDecimal.class, NULL_BIG_DECIMAL);
     NULL_CACHE.put(DateTime.class, NULL_DATE_TIME);
+    NULL_CACHE.put(Object.class, NULL_OBJECT);
   }
 
   /**


### PR DESCRIPTION
https://github.com/oracle/graal/issues/11429 confirms a behavior problem when calling `Object.class.newInstance()`. This is a temporary workaround while the GraalVM team looks into this.

Since `Data` relies on `Types.newInstance()` which ends up calling `Class.newInstance()`, we preemtively add a new representation "`NULL_OBJECT`" using `new Object()` instead to avoid the mysterious `SerializationSupport$StubForAbstractClass` that comes instead of object in Graal 24 compiled images.

More context and investigation in [tracking doc](https://docs.google.com/document/d/1Ij4nmBNsqY3-2GPEpUoGCptrqlKBfv-XOYjb6ly6UcA/edit?resourcekey=0-KaxXkGPeDJQdN61aeT-s1A&tab=t.7jx3c8lk2lvz).