### PR TITLE
deps: Bump errorprone to v2.41.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.36.0</version>
+        <version>2.41.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.appengine</groupId>


### PR DESCRIPTION
Found in: https://github.com/googleapis/google-http-java-client/pull/2127

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (enforce-maven) on project google-http-client: 
Error:  Rule 2: org.apache.maven.enforcer.rules.dependency.RequireUpperBoundDeps failed with message:
Error:  Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Error:  Require upper bound dependencies error for com.google.j2objc:j2objc-annotations:3.0.0 paths to dependency are:
Error:  +-com.google.http-client:google-http-client:2.0.3-SNAPSHOT
Error:    +-com.google.j2objc:j2objc-annotations:3.0.0
Error:  and
Error:  +-com.google.http-client:google-http-client:2.0.3-SNAPSHOT
Error:    +-com.google.guava:guava:33.5.0-android
Error:      +-com.google.j2objc:j2objc-annotations:3.0.0 (managed) <-- com.google.j2objc:j2objc-annotations:3.1
Error:  , 
Error:  Require upper bound dependencies error for com.google.errorprone:error_prone_annotations:2.36.0 paths to dependency are:
Error:  +-com.google.http-client:google-http-client:2.0.3-SNAPSHOT
Error: [ERROR]   +-com.google.errorprone:error_prone_annotations:2.36.0
Error:  and
Error:  +-com.google.http-client:google-http-client:2.0.3-SNAPSHOT
Error:    +-com.google.guava:guava:33.5.0-android
Error:      +-com.google.errorprone:error_prone_annotations:2.36.0 (managed) <-- com.google.errorprone:error_prone_annotations:2.41.0
Error:  ]
```