### PR TITLE
chore: cleanup release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -2,21 +2,21 @@ bumpMinorPreMajor: true
 handleGHRelease: true
 releaseType: java-yoshi
 branches:
-    - releaseType: java-lts
-      branch: 1.39.2-sp
-    - releaseType: java-backport
-      branch: 1.40.x
-    - releaseType: java-backport
-      branch: 1.41.x
-    - releaseType: java-backport
-      branch: 1.42.x
-    - releaseType: java-backport
-      branch: 1.43.x
-    - releaseType: java-backport
-      branch: 1.44.x
-    - releaseType: java-backport
-      branch: 1.46.x
-    - releaseType: java-backport
-      branch: 1.47.x
+    - branch: 1.39.2-sp
+      releaseType: java-lts
+    - branch: 1.40.x
+      releaseType: java-backport
+    - branch: 1.41.x
+      releaseType: java-backport
+    - branch: 1.42.x
+      releaseType: java-backport
+    - branch: 1.43.x
+      releaseType: java-backport
+    - branch: 1.44.x
+      releaseType: java-backport
+    - branch: 1.46.x
+      releaseType: java-backport
+    - branch: 1.47.x
+      releaseType: java-backport
     - branch: protobuf-4.x-rc
       manifest: true


### PR DESCRIPTION
This PR cleans up the .github/release-please.yml file by removing redundant options and the bump-minor-pre-major setting for major releases.