### PR TITLE
fix: add containsKey override for GenericData class

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/ClassInfo.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/ClassInfo.java
@@ -113,6 +113,23 @@ public final class ClassInfo {
   }
 
   /**
+   * Returns whether information for the given {@link FieldInfo#getName()}
+   * is available.
+   *
+   * @param name {@link FieldInfo#getName()} or {@code null}
+   * @return true if field info is available.
+   */
+  public boolean hasFieldInfo(String name) {
+    if (name != null) {
+      if (ignoreCase) {
+        name = name.toLowerCase(Locale.US);
+      }
+      name = name.intern();
+    }
+    return nameToFieldInfoMap.containsKey(name);
+  }
+  
+  /**
    * Returns the information for the given {@link FieldInfo#getName()}.
    *
    * @param name {@link FieldInfo#getName()} or {@code null}

--- a/google-http-client/src/main/java/com/google/api/client/util/ClassInfo.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/ClassInfo.java
@@ -113,8 +113,7 @@ public final class ClassInfo {
   }
 
   /**
-   * Returns whether information for the given {@link FieldInfo#getName()}
-   * is available.
+   * Returns whether information for the given {@link FieldInfo#getName()} is available.
    *
    * @param name {@link FieldInfo#getName()} or {@code null}
    * @return true if field info is available.
@@ -128,7 +127,7 @@ public final class ClassInfo {
     }
     return nameToFieldInfoMap.containsKey(name);
   }
-  
+
   /**
    * Returns the information for the given {@link FieldInfo#getName()}.
    *

--- a/google-http-client/src/main/java/com/google/api/client/util/GenericData.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/GenericData.java
@@ -80,8 +80,8 @@ public class GenericData extends AbstractMap<String, Object> implements Cloneabl
       return false;
     }
     String fieldName = (String) name;
-    FieldInfo fieldInfo = classInfo.getFieldInfo(fieldName);
-    if (fieldInfo != null) {
+    boolean hasFieldInfo = classInfo.hasFieldInfo(fieldName);
+    if (hasFieldInfo) {
       return true;
     }
     if (classInfo.getIgnoreCase()) {

--- a/google-http-client/src/main/java/com/google/api/client/util/GenericData.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/GenericData.java
@@ -75,6 +75,22 @@ public class GenericData extends AbstractMap<String, Object> implements Cloneabl
   }
 
   @Override
+  public final boolean containsKey(Object name) {
+    if (!(name instanceof String)) {
+      return false;
+    }
+    String fieldName = (String) name;
+    FieldInfo fieldInfo = classInfo.getFieldInfo(fieldName);
+    if (fieldInfo != null) {
+      return true;
+    }
+    if (classInfo.getIgnoreCase()) {
+      fieldName = fieldName.toLowerCase(Locale.US);
+    }
+    return unknownFields.containsKey(fieldName);
+  }
+
+  @Override
   public final Object get(Object name) {
     if (!(name instanceof String)) {
       return null;

--- a/google-http-client/src/test/java/com/google/api/client/util/ClassInfoTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/ClassInfoTest.java
@@ -58,6 +58,15 @@ public class ClassInfoTest {
     assertEquals(E.class.getField("VALUE"), classInfo.getFieldInfo("VALUE").getField());
   }
 
+  @Test
+  public void testHasFieldInfo_enum() throws Exception {
+    ClassInfo classInfo = ClassInfo.of(E.class);
+    assertFalse(classInfo.hasFieldInfo("wrong"));
+    assertTrue(classInfo.hasFieldInfo(null));
+    assertTrue(classInfo.hasFieldInfo("other"));
+    assertTrue(classInfo.hasFieldInfo("VALUE"));
+  }
+
   public class A {
     @Key String b;
 

--- a/google-http-client/src/test/java/com/google/api/client/util/GenericDataTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/GenericDataTest.java
@@ -156,6 +156,7 @@ public class GenericDataTest {
   public void testGetIgnoreCase_class() {
     MyData data = new MyData();
     data.fieldA = "someValue";
+    assertTrue(data.containsKey("FIELDA"));
     assertEquals("someValue", data.get("FIELDA"));
   }
 
@@ -187,11 +188,14 @@ public class GenericDataTest {
   public void testGetIgnoreCase_unknownKey() {
     GenericData data = new GenericData(EnumSet.of(Flags.IGNORE_CASE));
     data.set("One", 1);
+    assertTrue(data.containsKey("ONE"));
     assertEquals(1, data.get("ONE"));
 
     data.set("one", 2);
+    assertTrue(data.containsKey("ONE"));
     assertEquals(2, data.get("ONE"));
 
+    assertFalse(data.containsKey("unknownKey"));
     assertEquals(null, data.get("unknownKey"));
   }
 


### PR DESCRIPTION
When running JFR profiling for Google BigQuery JDBC driver, I saw large amount of samples points to `Map.containsKey` function. 

<img width="1770" height="836" alt="image" src="https://github.com/user-attachments/assets/ae74dae9-7ec0-4df4-a9c1-21a9315c5f62" />

When I tried local changes to BQ Java SDK to avoid `containsKey` call and call `get()` instead & validate if result is null or not, calls to `get` function, they don't generate as many samples. 

Due to `containsKey` override missing, it falls back to the default `Map.containsKey` implementation which seems to be more expensive in the case of `GenericData` class. I didn't run sampler with these changes, but attaching results when `containsKey` was replaced with `get()` in the SDK.

<img width="1625" height="793" alt="image" src="https://github.com/user-attachments/assets/1e1f64d1-fda8-4bbf-bc8a-5d21272217d3" />

