### PR TITLE
fix: Update renovate config check to use npx

### DIFF
--- a/.github/workflows/renovate_config_check.yaml
+++ b/.github/workflows/renovate_config_check.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'renovate.json'
+      - '.github/workflows/renovate_config_check.yaml'
 
 jobs:
   renovate_bot_config_validation:
@@ -18,8 +19,6 @@ jobs:
       with:
         node-version: '20'
 
-    - name: Install Renovate and Config Validator
+    - name: Run Renovate Config Validator
       run: |
-        npm install -g npm@latest
-        npm install --global renovate
-        renovate-config-validator
+        npx --package renovate@42.99.0 renovate-config-validator

--- a/.github/workflows/renovate_config_check.yaml
+++ b/.github/workflows/renovate_config_check.yaml
@@ -21,4 +21,4 @@ jobs:
 
     - name: Run Renovate Config Validator
       run: |
-        npx --package renovate@42.99.0 renovate-config-validator
+        npx --package renovate@43.136.0 renovate-config-validator


### PR DESCRIPTION
This PR updates the renovate config check workflow to use npx instead of global installation, avoiding issues with missing modules.