### PR TITLE
Fix: abort connection before draining in HttpResponse.disconnect()

### DIFF
--- a/google-http-client-apache-v2/src/test/java/com/google/api/client/http/apache/v2/ApacheHttpTransportTest.java
+++ b/google-http-client-apache-v2/src/test/java/com/google/api/client/http/apache/v2/ApacheHttpTransportTest.java
@@ -338,4 +338,38 @@ public class ApacheHttpTransportTest {
   private boolean isWindows() {
     return System.getProperty("os.name").startsWith("Windows");
   }
+
+  @Test(timeout = 10_000L)
+  public void testDisconnectShouldNotWaitToReadResponse() throws IOException {
+    // This handler waits for 100s before returning writing content. The test should
+    // timeout if disconnect waits for the response before closing the connection.
+    final HttpHandler handler =
+        new HttpHandler() {
+          @Override
+          public void handle(HttpExchange httpExchange) throws IOException {
+            byte[] response = httpExchange.getRequestURI().toString().getBytes();
+            httpExchange.sendResponseHeaders(200, response.length);
+
+            // Sleep for longer than the test timeout
+            try {
+              Thread.sleep(100_000);
+            } catch (InterruptedException e) {
+              throw new IOException("interrupted", e);
+            }
+            try (OutputStream out = httpExchange.getResponseBody()) {
+              out.write(response);
+            }
+          }
+        };
+
+    try (FakeServer server = new FakeServer(handler)) {
+      HttpTransport transport = new ApacheHttpTransport();
+      GenericUrl testUrl = new GenericUrl("http://localhost/foo//bar");
+      testUrl.setPort(server.getPort());
+      com.google.api.client.http.HttpResponse response =
+          transport.createRequestFactory().buildGetRequest(testUrl).execute();
+      // disconnect should not wait to read the entire content
+      response.disconnect();
+    }
+  }
 }

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponse.java
@@ -438,11 +438,20 @@ public final class HttpResponse {
    * Disconnect using {@link LowLevelHttpResponse#disconnect()}, then close the HTTP response
    * content using {@link #ignore}.
    *
+   * <p>The underlying connection is aborted first so that closing the response content in {@link
+   * #ignore} does not block to drain remaining response bytes (e.g. when only a small prefix of a
+   * large response was read). Any {@link IOException} from {@link #ignore} after an abort is
+   * expected and silently swallowed.
+   *
    * @since 1.4
    */
   public void disconnect() throws IOException {
-    ignore();
     response.disconnect();
+    try {
+      ignore();
+    } catch (IOException e) {
+      // Expected when the connection was aborted before content was fully consumed.
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #1303

After the revert https://github.com/googleapis/google-http-java-client/pull/1427 was merged, this issue was never looked upon. This issue is causing `fadvice: SEQUENTIAL` (default) file reads in https://github.com/GoogleCloudDataproc/hadoop-connectors/issues/1729 to read the file full from the point it was seeked to. Hence for reading 2gb out of 40gb file, after reading the file for 2gb and calling disconnect()/close() we're still draining the rest of 38gb stream due to this.

HttpResponse.disconnect() calls ignore() (which drains the remaining response body via ContentLengthInputStream.close()) before calling LowLevelHttpResponse.disconnect() (which aborts the socket). This caused callers that close a stream after reading only a prefix of a large response to block for minutes draining bytes they do not need.

---

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-http-java-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)