### PR TITLE
test: Use local FakeServer in tests to avoid real network calls

### DIFF
--- a/google-http-client-apache-v2/src/test/java/com/google/api/client/http/apache/v2/ApacheHttpTransportTest.java
+++ b/google-http-client-apache-v2/src/test/java/com/google/api/client/http/apache/v2/ApacheHttpTransportTest.java
@@ -40,11 +40,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.http.Header;
-import org.apache.http.HttpClientConnection;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
@@ -55,7 +53,6 @@ import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.protocol.HttpContext;
-import org.apache.http.protocol.HttpRequestExecutor;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -162,25 +159,38 @@ public class ApacheHttpTransportTest {
 
   @Test
   public void testRequestShouldNotFollowRedirects() throws IOException {
-    final AtomicInteger requestsAttempted = new AtomicInteger(0);
-    HttpRequestExecutor requestExecutor =
-        new HttpRequestExecutor() {
+    final AtomicInteger requestCount = new AtomicInteger(0);
+    final AtomicBoolean redirected = new AtomicBoolean(false);
+    final HttpHandler handler =
+        new HttpHandler() {
           @Override
-          public HttpResponse execute(
-              HttpRequest request, HttpClientConnection connection, HttpContext context)
-              throws IOException, HttpException {
-            HttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 302, null);
-            response.addHeader("location", "https://google.com/path");
-            requestsAttempted.incrementAndGet();
-            return response;
+          public void handle(HttpExchange httpExchange) throws IOException {
+            requestCount.incrementAndGet();
+            String path = httpExchange.getRequestURI().getPath();
+            if ("/redirected".equals(path)) {
+              redirected.set(true);
+              httpExchange.sendResponseHeaders(200, -1);
+            } else {
+              int port = httpExchange.getLocalAddress().getPort();
+              httpExchange
+                  .getResponseHeaders()
+                  .add("Location", "http://localhost:" + port + "/redirected");
+              httpExchange.sendResponseHeaders(302, -1);
+            }
+            httpExchange.close();
           }
         };
-    HttpClient client = HttpClients.custom().setRequestExecutor(requestExecutor).build();
-    ApacheHttpTransport transport = new ApacheHttpTransport(client);
-    ApacheHttpRequest request = transport.buildRequest("GET", "https://google.com");
-    LowLevelHttpResponse response = request.execute();
-    assertEquals(1, requestsAttempted.get());
-    assertEquals(302, response.getStatusCode());
+
+    try (FakeServer server = new FakeServer(handler)) {
+      HttpClient client = HttpClients.custom().build();
+      ApacheHttpTransport transport = new ApacheHttpTransport(client);
+      ApacheHttpRequest request =
+          transport.buildRequest("GET", "http://localhost:" + server.getPort() + "/");
+      LowLevelHttpResponse response = request.execute();
+      assertEquals(302, response.getStatusCode());
+      assertEquals(1, requestCount.get());
+      assertFalse(redirected.get());
+    }
   }
 
   @Test
@@ -203,7 +213,7 @@ public class ApacheHttpTransportTest {
             .build();
 
     ApacheHttpTransport transport = new ApacheHttpTransport(client);
-    ApacheHttpRequest request = transport.buildRequest("GET", "https://google.com");
+    ApacheHttpRequest request = transport.buildRequest("GET", "http://localhost/");
     request.addHeader("foo", "bar");
     try {
       LowLevelHttpResponse response = request.execute();

--- a/google-http-client-apache-v5/src/test/java/com/google/api/client/http/apache/v5/Apache5HttpTransportTest.java
+++ b/google-http-client-apache-v5/src/test/java/com/google/api/client/http/apache/v5/Apache5HttpTransportTest.java
@@ -48,9 +48,7 @@ import org.apache.hc.core5.http.HttpRequestMapper;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.impl.bootstrap.HttpServer;
-import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
 import org.apache.hc.core5.http.impl.io.HttpService;
-import org.apache.hc.core5.http.io.HttpClientConnection;
 import org.apache.hc.core5.http.io.HttpRequestHandler;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.support.BasicHttpServerRequestHandler;
@@ -134,32 +132,40 @@ public class Apache5HttpTransportTest {
 
   @Test
   public void testRequestShouldNotFollowRedirects() throws IOException {
-    final AtomicInteger requestsAttempted = new AtomicInteger(0);
-    HttpRequestExecutor requestExecutor =
-        new HttpRequestExecutor() {
+    final AtomicInteger requestCount = new AtomicInteger(0);
+    final AtomicBoolean redirected = new AtomicBoolean(false);
+    final HttpRequestHandler handler =
+        new HttpRequestHandler() {
           @Override
-          public ClassicHttpResponse execute(
-              ClassicHttpRequest request, HttpClientConnection connection, HttpContext context)
-              throws IOException, HttpException {
-            ClassicHttpResponse response = new MockClassicHttpResponse();
-            response.setCode(302);
-            response.setReasonPhrase(null);
-            response.addHeader("location", "https://google.com/path");
-            response.addHeader(HttpHeaders.SET_COOKIE, "");
-            requestsAttempted.incrementAndGet();
-            return response;
+          public void handle(
+              ClassicHttpRequest request, ClassicHttpResponse response, HttpContext context)
+              throws HttpException, IOException {
+            requestCount.incrementAndGet();
+            String path = request.getRequestUri();
+            if ("/redirected".equals(path)) {
+              redirected.set(true);
+              response.setCode(200);
+            } else {
+              response.setCode(302);
+              response.setHeader(HttpHeaders.LOCATION, "/redirected");
+            }
           }
         };
-    HttpClient client = HttpClients.custom().setRequestExecutor(requestExecutor).build();
-    Apache5HttpTransport transport = new Apache5HttpTransport(client);
-    Apache5HttpRequest request = transport.buildRequest("GET", "https://google.com");
-    LowLevelHttpResponse response = request.execute();
-    assertEquals(1, requestsAttempted.get());
-    assertEquals(302, response.getStatusCode());
+
+    try (FakeServer server = new FakeServer(handler)) {
+      HttpClient client = HttpClients.custom().build();
+      Apache5HttpTransport transport = new Apache5HttpTransport(client);
+      Apache5HttpRequest request =
+          transport.buildRequest("GET", "http://localhost:" + server.getPort() + "/");
+      LowLevelHttpResponse response = request.execute();
+      assertEquals(302, response.getStatusCode());
+      assertEquals(1, requestCount.get());
+      assertFalse(redirected.get());
+    }
   }
 
   @Test
-  public void testRequestCanSetHeaders() {
+  public void testRequestCanSetHeaders() throws IOException {
     final AtomicBoolean interceptorCalled = new AtomicBoolean(false);
     HttpClient client =
         HttpClients.custom()
@@ -178,16 +184,26 @@ public class Apache5HttpTransportTest {
                 })
             .build();
 
-    Apache5HttpTransport transport = new Apache5HttpTransport(client);
-    Apache5HttpRequest request = transport.buildRequest("GET", "https://google.com");
-    request.addHeader("foo", "bar");
-    try {
-      LowLevelHttpResponse response = request.execute();
-      fail("should not actually make the request");
-    } catch (IOException exception) {
-      assertEquals("cancelling request", exception.getMessage());
+    HttpRequestHandler dummyHandler =
+        new HttpRequestHandler() {
+          @Override
+          public void handle(
+              ClassicHttpRequest request, ClassicHttpResponse response, HttpContext context) {}
+        };
+
+    try (FakeServer server = new FakeServer(dummyHandler)) {
+      Apache5HttpTransport transport = new Apache5HttpTransport(client);
+      Apache5HttpRequest request =
+          transport.buildRequest("GET", "http://localhost:" + server.getPort() + "/");
+      request.addHeader("foo", "bar");
+      try {
+        LowLevelHttpResponse response = request.execute();
+        fail("should not actually make the request");
+      } catch (IOException exception) {
+        assertEquals("cancelling request", exception.getMessage());
+      }
+      assertTrue("Expected to have called our test interceptor", interceptorCalled.get());
     }
-    assertTrue("Expected to have called our test interceptor", interceptorCalled.get());
   }
 
   @Test(timeout = 10_000L)


### PR DESCRIPTION
Error from https://github.com/googleapis/google-http-java-client/pull/2164

---

Rewrite testRequestShouldNotFollowRedirects to use a local FakeServer
instead of connecting to google.com, avoiding SSL handshake failures
in environments without proper trust stores (like GraalVM native image tests).

Also update testRequestCanSetHeaders to use localhost dummy URL.

TAG=agy
CONV=b7638222-8f45-4b8a-8698-ae587dfa7e88