### PR TITLE
fix: declare commons-codec as direct dependency in google-http-client

### DIFF
--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -25,6 +25,7 @@
             <ignoredUnusedDeclaredDependencies>
               <ignoredUnusedDeclaredDependency>io.opencensus:opencensus-impl</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>io.grpc:grpc-context</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>commons-codec:commons-codec</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>
@@ -125,6 +126,10 @@
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
This ensures that consumers of google-http-client (like google-auth-library) resolve commons-codec to the intended version (1.14) instead of falling back to the transitive default from httpclient (1.11).

### Verification
Below is the comparison of `mvn dependency:tree` on `google-auth-library-oauth2-http` before and after this change, demonstrating that `commons-codec` is now correctly resolved to `1.14` transitively.
#### Before (with google-http-client v2.1.1)
`commons-codec` resolved to `1.11` via `httpclient`:
```text
[INFO] +- com.google.http-client:google-http-client:jar:2.1.1:compile
[INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.5.14:compile
[INFO] |  |  \- commons-codec:commons-codec:jar:1.11:compile
```

#### After
```
[INFO] +- com.google.http-client:google-http-client:jar:2.1.2-SNAPSHOT:compile
[INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.5.14:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.14:compile
```
