### PR TITLE
security: strip cookies on cross-origin redirects and fix response connection leaks

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -29,6 +29,7 @@ import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracer;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
@@ -1022,10 +1023,17 @@ public final class HttpRequest {
           response = new HttpResponse(this, lowLevelHttpResponse);
           responseConstructed = true;
         } finally {
-          if (!responseConstructed) {
-            InputStream lowLevelContent = lowLevelHttpResponse.getContent();
-            if (lowLevelContent != null) {
-              lowLevelContent.close();
+          if (!responseConstructed && lowLevelHttpResponse != null) {
+            try {
+              InputStream lowLevelContent = lowLevelHttpResponse.getContent();
+              if (lowLevelContent != null) {
+                lowLevelContent.close();
+              }
+            } catch (IOException ignored) {
+            }
+            try {
+              lowLevelHttpResponse.disconnect();
+            } catch (IOException ignored) {
             }
           }
         }
@@ -1180,7 +1188,25 @@ public final class HttpRequest {
         && HttpStatusCodes.isRedirect(statusCode)
         && redirectLocation != null) {
       // resolve the redirect location relative to the current location
-      setUrl(new GenericUrl(url.toURL(redirectLocation), useRawRedirectUrls));
+      URL newURL = url.toURL(redirectLocation);
+
+      // Check if redirecting to a different origin
+      String oldScheme = url.getScheme();
+      String oldHost = url.getHost();
+      int oldPort = url.getPort();
+
+      String newScheme = newURL.getProtocol();
+      String newHost = newURL.getHost();
+      int newPort = newURL.getPort();
+
+      int oldEffectivePort = getEffectivePort(oldScheme, oldPort);
+      int newEffectivePort = getEffectivePort(newScheme, newPort);
+
+      boolean sameOrigin = (oldScheme == null ? newScheme == null : oldScheme.equalsIgnoreCase(newScheme))
+          && (oldHost == null ? newHost == null : oldHost.equalsIgnoreCase(newHost))
+          && (oldEffectivePort == newEffectivePort);
+
+      setUrl(new GenericUrl(newURL, useRawRedirectUrls));
       // on 303 change method to GET
       if (statusCode == HttpStatusCodes.STATUS_CODE_SEE_OTHER) {
         setRequestMethod(HttpMethods.GET);
@@ -1194,9 +1220,27 @@ public final class HttpRequest {
       headers.setIfModifiedSince((String) null);
       headers.setIfUnmodifiedSince((String) null);
       headers.setIfRange((String) null);
+
+      // remove Cookie header if redirect is cross-origin
+      if (!sameOrigin) {
+        headers.setCookie((String) null);
+      }
       return true;
     }
     return false;
+  }
+
+  private static int getEffectivePort(String scheme, int port) {
+    if (port != -1) {
+      return port;
+    }
+    if ("http".equalsIgnoreCase(scheme)) {
+      return 80;
+    }
+    if ("https".equalsIgnoreCase(scheme)) {
+      return 443;
+    }
+    return -1;
   }
 
   /**

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTest.java
@@ -543,6 +543,92 @@ public class HttpRequestTest {
     assertEquals(newLocation, req.getUrl().toString());
   }
 
+  @Test
+  public void testHandleRedirect_crossOriginCookieRemoval() throws IOException {
+    // 1. Same-origin redirect (http://some.org/a/b -> http://some.org/a/z)
+    {
+      HttpTransport transport = new MockHttpTransport();
+      HttpRequest req = transport.createRequestFactory().buildGetRequest(new GenericUrl("http://some.org/a/b"));
+      req.getHeaders().setCookie("foo=bar");
+      HttpHeaders responseHeaders = new HttpHeaders().setLocation("http://some.org/a/z");
+      req.handleRedirect(HttpStatusCodes.STATUS_CODE_SEE_OTHER, responseHeaders);
+      assertEquals("foo=bar", req.getHeaders().getCookie());
+      assertEquals("http://some.org/a/z", req.getUrl().toString());
+    }
+
+    // 2. Cross-origin redirect due to host change (http://some.org/a/b -> http://other.org/c)
+    {
+      HttpTransport transport = new MockHttpTransport();
+      HttpRequest req = transport.createRequestFactory().buildGetRequest(new GenericUrl("http://some.org/a/b"));
+      req.getHeaders().setCookie("foo=bar");
+      HttpHeaders responseHeaders = new HttpHeaders().setLocation("http://other.org/c");
+      req.handleRedirect(HttpStatusCodes.STATUS_CODE_SEE_OTHER, responseHeaders);
+      assertNull(req.getHeaders().getCookie());
+      assertEquals("http://other.org/c", req.getUrl().toString());
+    }
+
+    // 3. Cross-origin redirect due to scheme change (https://some.org/a/b -> http://some.org/a/z)
+    {
+      HttpTransport transport = new MockHttpTransport();
+      HttpRequest req = transport.createRequestFactory().buildGetRequest(new GenericUrl("https://some.org/a/b"));
+      req.getHeaders().setCookie("foo=bar");
+      HttpHeaders responseHeaders = new HttpHeaders().setLocation("http://some.org/a/z");
+      req.handleRedirect(HttpStatusCodes.STATUS_CODE_SEE_OTHER, responseHeaders);
+      assertNull(req.getHeaders().getCookie());
+      assertEquals("http://some.org/a/z", req.getUrl().toString());
+    }
+
+    // 4. Cross-origin redirect due to port change (http://some.org/a/b -> http://some.org:8080/a/z)
+    {
+      HttpTransport transport = new MockHttpTransport();
+      HttpRequest req = transport.createRequestFactory().buildGetRequest(new GenericUrl("http://some.org/a/b"));
+      req.getHeaders().setCookie("foo=bar");
+      HttpHeaders responseHeaders = new HttpHeaders().setLocation("http://some.org:8080/a/z");
+      req.handleRedirect(HttpStatusCodes.STATUS_CODE_SEE_OTHER, responseHeaders);
+      assertNull(req.getHeaders().getCookie());
+      assertEquals("http://some.org:8080/a/z", req.getUrl().toString());
+    }
+
+    // 5. Same-origin redirect with implicit/explicit default ports matching (http://some.org/a/b -> http://some.org:80/a/z)
+    {
+      HttpTransport transport = new MockHttpTransport();
+      HttpRequest req = transport.createRequestFactory().buildGetRequest(new GenericUrl("http://some.org/a/b"));
+      req.getHeaders().setCookie("foo=bar");
+      HttpHeaders responseHeaders = new HttpHeaders().setLocation("http://some.org:80/a/z");
+      req.handleRedirect(HttpStatusCodes.STATUS_CODE_SEE_OTHER, responseHeaders);
+      assertEquals("foo=bar", req.getHeaders().getCookie());
+      assertEquals("http://some.org:80/a/z", req.getUrl().toString());
+    }
+  }
+
+  @Test
+  public void testExecute_disconnectOnResponseConstructionFailure() throws Exception {
+    class FailingHttpResponse extends MockLowLevelHttpResponse {
+      @Override
+      public String getContentEncoding() {
+        throw new RuntimeException("Simulated response construction failure");
+      }
+    }
+
+    final FailingHttpResponse failingResponse = new FailingHttpResponse();
+    HttpTransport transport = new MockHttpTransport() {
+      @Override
+      public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+        return new MockLowLevelHttpRequest().setResponse(failingResponse);
+      }
+    };
+
+    HttpRequest req = transport.createRequestFactory().buildGetRequest(new GenericUrl("http://example.com"));
+    try {
+      req.execute();
+      fail("Expected RuntimeException");
+    } catch (RuntimeException e) {
+      assertEquals("Simulated response construction failure", e.getMessage());
+    }
+
+    assertTrue(failingResponse.isDisconnected());
+  }
+
   @Deprecated
   @Test
   public void testExecuteErrorWithRetryEnabled() throws Exception {


### PR DESCRIPTION
Summary

Cross-Origin Cookie Removal on Redirects 

Problem: When `HttpRequest` follows a redirect to a different origin (different scheme, host, or effective port), sensitive `Cookie` headers could be forwarded to the redirect destination, potentially exposing session credentials.

Fix: Updated `handleRedirect()` to compare the redirect target's scheme, host, and effective port with the current request URL. If the redirect is cross-origin, the `Cookie` header is removed before following the redirect. Same-origin redirects continue to preserve cookies.

 Resource Cleanup on Response Construction Failure 

Problem: If `new HttpResponse(this, lowLevelHttpResponse)` throws an exception before the response is fully constructed, the underlying `LowLevelHttpResponse` may not be released, potentially leaving underlying HTTP resources open.

Fix: Updated the cleanup logic in the `finally` block of `execute()` to close the response content (when present) and invoke `disconnect()` on `lowLevelHttpResponse` when response construction fails, ensuring cleanup exceptions do not mask the original exception.

Tests Added 

Added `testHandleRedirect_crossOriginCookieRemoval` to verify that cookies are removed for cross-origin redirects while remaining intact for same-origin redirects, including cases involving implicit and explicit default ports. Added `testExecute_disconnectOnResponseConstructionFailure` to verify that `disconnect()` is invoked when response construction fails and that the original exception is preserved during cleanup.

 Verification  

All 45 tests in `HttpRequestTest` passed successfully. A full `mvn clean install` also completed successfully across all 15 modules with `BUILD SUCCESS`, confirming the changes behave as expected and do not introduce regressions.
