### PR TITLE
docs: restore ProGuard setup instructions

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -75,6 +75,25 @@ If you are using Gradle, add this to your dependencies:
 compile 'com.google.http-client:google-http-client:[VERSION]'
 ```
 
+## ProGuard
+
+The library uses reflection to access generic types and fields annotated with `@Key`. Add the
+following rules to your ProGuard configuration:
+
+```
+-keepattributes Signature,RuntimeVisibleAnnotations,AnnotationDefault
+
+-keepclassmembers class * {
+  @com.google.api.client.util.Key <fields>;
+}
+```
+
+When using `google-http-client-android`, also add:
+
+```
+-dontwarn com.google.api.client.extensions.android.**
+```
+
 ## Download the library with dependencies
 
 Download the latest assembly zip file from Maven Central and extract it on your computer. This zip
@@ -82,7 +101,6 @@ contains the client library class jar files and the associated source jar files 
 and their dependencies. You can find dependency graphs and licenses for the different libraries in
 the dependencies folder. For more details about the contents of the download, see the contained
 `readme.html` file.
-
 
 
 


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-http-java-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2089 ☕️

## Summary

Restores the missing ProGuard section in the setup documentation using the existing rules from `google-http-client-assembly/proguard-google-http-client.txt`.

The documentation also separates the Android-specific warning suppression from the common rules, making the instructions applicable to desktop applications.

## Validation

- `git diff --check`
- Documentation-only change; Java tests were not required