### PR TITLE
fix: shut down executeAsync executor

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
@@ -1148,15 +1149,21 @@ public final class HttpRequest {
   /**
    * {@link Beta} <br>
    * Executes this request asynchronously using {@link #executeAsync(Executor)} in a single separate
-   * thread using {@link Executors#newFixedThreadPool(int)}.
+   * thread using {@link Executors#newFixedThreadPool(int)}. The executor is shut down after the
+   * request has been submitted.
    *
    * @return A future for accessing the results of the asynchronous request.
    * @since 1.13
    */
   @Beta
   public Future<HttpResponse> executeAsync() {
-    return executeAsync(
-        Executors.newFixedThreadPool(1, new ThreadFactoryBuilder().setDaemon(true).build()));
+    ExecutorService executor =
+        Executors.newFixedThreadPool(1, new ThreadFactoryBuilder().setDaemon(true).build());
+    try {
+      return executeAsync(executor);
+    } finally {
+      executor.shutdown();
+    }
   }
 
   /**

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTest.java
@@ -41,7 +41,9 @@ import com.google.common.collect.Lists;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
@@ -1207,6 +1209,42 @@ public class HttpRequestTest {
     mockExecutor.actuallyRun();
     assertTrue(futureResponse.isDone());
     assertNotNull(futureResponse.get(10, TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  public void testExecuteAsync_defaultExecutorDoesNotLeakThreads() throws Exception {
+    Set<Long> threadsBeforeTest = getThreadIds();
+    HttpTransport transport = new MockHttpTransport();
+
+    for (int i = 0; i < 20; i++) {
+      HttpRequest request =
+          transport.createRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
+      assertNotNull(request.executeAsync().get(10, TimeUnit.SECONDS));
+    }
+
+    long timeout = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+    while (hasNewExecutorThread(threadsBeforeTest) && System.currentTimeMillis() < timeout) {
+      Thread.sleep(10);
+    }
+    assertFalse(hasNewExecutorThread(threadsBeforeTest));
+  }
+
+  private static Set<Long> getThreadIds() {
+    Set<Long> threadIds = new HashSet<Long>();
+    for (Thread thread : Thread.getAllStackTraces().keySet()) {
+      threadIds.add(thread.getId());
+    }
+    return threadIds;
+  }
+
+  private static boolean hasNewExecutorThread(Set<Long> threadsBeforeTest) {
+    for (Thread thread : Thread.getAllStackTraces().keySet()) {
+      if (!threadsBeforeTest.contains(thread.getId())
+          && thread.getName().matches("pool-\\d+-thread-\\d+")) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Test


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-http-java-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2122 ☕️

## Description

Shuts down the executor created by the zero-argument `HttpRequest.executeAsync()` after submitting the request. Previously, every invocation created a fixed thread pool that was never shut down, leaving its worker thread alive indefinitely.

The executor is shut down in a `finally` block, allowing the submitted request to finish while ensuring its worker thread terminates afterward.

## Testing

- Added a regression test that executes multiple asynchronous requests and verifies that the executor threads terminate.
- Ran `HttpRequestTest`: 44 tests passed.
- Applied Google Java Format.
- Verified the changes with `git diff --check`.

No sample code was added.