### PR TITLE
fix: avoid exception-based Base64 decoder selection

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/Base64.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Base64.java
@@ -15,7 +15,6 @@
 package com.google.api.client.util;
 
 import com.google.common.io.BaseEncoding;
-import com.google.common.io.BaseEncoding.DecodingException;
 
 /**
  * Proxy for handling Base64 encoding/decoding.
@@ -99,8 +98,8 @@ public class Base64 {
    * Decodes a Base64 String into octets. Note that this method handles both URL-safe and
    * non-URL-safe base 64 encoded strings.
    *
-   * <p>For the compatibility with the old version that used Apache Commons Coded's decodeBase64,
-   * this method discards new line characters and trailing whitespaces.
+   * <p>For compatibility with the old version that used Apache Commons Codec's decodeBase64, this
+   * method discards new line characters and trailing whitespaces.
    *
    * @param base64String String containing Base64 data or {@code null} for {@code null} result
    * @return Array containing decoded data or {@code null} for {@code null} input
@@ -109,14 +108,12 @@ public class Base64 {
     if (base64String == null) {
       return null;
     }
-    try {
-      return BASE64_DECODER.decode(base64String);
-    } catch (IllegalArgumentException e) {
-      if (e.getCause() instanceof DecodingException) {
-        return BASE64URL_DECODER.decode(base64String.trim());
-      }
-      throw e;
-    }
+    String normalizedBase64String = base64String.trim();
+    BaseEncoding decoder =
+        normalizedBase64String.indexOf('-') >= 0 || normalizedBase64String.indexOf('_') >= 0
+            ? BASE64URL_DECODER
+            : BASE64_DECODER;
+    return decoder.decode(normalizedBase64String);
   }
 
   private Base64() {}

--- a/google-http-client/src/test/java/com/google/api/client/util/Base64Test.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/Base64Test.java
@@ -44,6 +44,21 @@ public class Base64Test {
   }
 
   @Test
+  public void test_decodeBase64_urlSafe() {
+    assertThat(Base64.decodeBase64("-_8=")).isEqualTo(new byte[] {(byte) 0xfb, (byte) 0xff});
+  }
+
+  @Test
+  public void test_decodeBase64_urlSafeWithoutPadding() {
+    assertThat(Base64.decodeBase64("-_8")).isEqualTo(new byte[] {(byte) 0xfb, (byte) 0xff});
+  }
+
+  @Test
+  public void test_decodeBase64_urlSafeWithTrailingWhitespace() {
+    assertThat(Base64.decodeBase64("-_8=\r\n")).isEqualTo(new byte[] {(byte) 0xfb, (byte) 0xff});
+  }
+
+  @Test
   public void test_decodeBase64_withTrailingWhitespace() {
     // Some internal use cases append extra space characters that apache-commons base64 decoding
     // previously handled.


### PR DESCRIPTION

- [x] An issue was opened and discussed before writing the code
- [x] Tests and linting pass
- [x] Code coverage does not decrease; regression tests were added for Base64url decoding
- [x] Appropriate documentation was updated

Fixes #2159 ☕️

This change avoids using exceptions to select between standard Base64 and Base64url decoders. It normalizes trailing whitespace, detects Base64url-specific characters (`-` and `_`), and selects the appropriate decoder directly.

Regression tests cover padded, unpadded, and trailing-whitespace Base64url input.