### PR TITLE
build: replace FindBugs with SpotBugs

### DIFF
--- a/google-http-client-findbugs/google-http-client-findbugs-test/pom.xml
+++ b/google-http-client-findbugs/google-http-client-findbugs-test/pom.xml
@@ -4,8 +4,8 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.http-client</groupId>
   <artifactId>google-http-client-findbugs-test</artifactId>
-  <version>1.15.0-rc-SNAPSHOT</version>
-  <name>Findbugs Google API Client Library plugin test.</name>
+  <version>2.1.2-SNAPSHOT</version>
+  <name>SpotBugs Google API Client Library plugin test.</name>
   <packaging>jar</packaging>
   <build>
     <plugins>
@@ -30,9 +30,9 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.5</version>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.8.6.8</version>
         <configuration>
           <plugins>
             <plugin>

--- a/google-http-client-findbugs/pom.xml
+++ b/google-http-client-findbugs/pom.xml
@@ -9,7 +9,11 @@
   </parent>
   <artifactId>google-http-client-findbugs</artifactId>
   <version>2.1.2-SNAPSHOT</version><!-- {x-version-update:google-http-client-findbugs:current} -->
-  <name>Google APIs Client Library Findbugs custom plugin.</name>
+  <name>Google APIs Client Library SpotBugs custom plugin.</name>
+  <description>
+    SpotBugs plugin for detecting usages of beta Google HTTP Client APIs. The artifact ID retains
+    its historical name for compatibility.
+  </description>
 
   <build>
     <pluginManagement>
@@ -50,28 +54,10 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>findbugs</artifactId>
-      <version>3.0.1</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>xalan</artifactId>
-          <groupId>xalan</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>xmlParserAPIs</artifactId>
-          <groupId>xerces</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>annotations</artifactId>
-          <groupId>com.google.code.findbugs</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>bcel-findbugs</artifactId>
-      <version>6.0</version>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs</artifactId>
+      <version>4.8.6</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>

--- a/google-http-client-findbugs/src/main/java/com/google/api/client/findbugs/BetaDetector.java
+++ b/google-http-client-findbugs/src/main/java/com/google/api/client/findbugs/BetaDetector.java
@@ -18,6 +18,9 @@ import com.google.api.client.util.Beta;
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import edu.umd.cs.findbugs.visitclass.Constants2;
+import org.apache.bcel.Const;
+import org.apache.bcel.Constants;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.AnnotationEntry;
 import org.apache.bcel.classfile.ConstantClass;
@@ -26,11 +29,11 @@ import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 
 /**
- * Findbugs plugin detector which detects usage of {@link Beta} in your code.
+ * SpotBugs plugin detector which detects usage of {@link Beta} in your code.
  *
  * @author Eyal Peled
  */
-public class BetaDetector extends OpcodeStackDetector {
+public class BetaDetector extends OpcodeStackDetector implements Constants, Constants2 {
 
   /** Beta annotation "signature". */
   private static final String BETA_ANNOTATION = "Lcom/google/api/client/util/Beta;";
@@ -54,33 +57,25 @@ public class BetaDetector extends OpcodeStackDetector {
   @Override
   public void sawOpcode(int seen) {
     switch (seen) {
-      case INVOKEINTERFACE:
-      case INVOKESTATIC:
-      case INVOKESPECIAL:
-      case INVOKEVIRTUAL:
+      case Const.INVOKEINTERFACE:
+      case Const.INVOKESTATIC:
+      case Const.INVOKESPECIAL:
+      case Const.INVOKEVIRTUAL:
         // Method usage
         checkMethod(getNameConstantOperand(), getSigConstantOperand());
         break;
 
-      case GETFIELD:
-      case GETFIELD_QUICK:
-      case GETFIELD_QUICK_W:
-      case PUTFIELD:
-      case PUTFIELD_QUICK:
-      case PUTFIELD_QUICK_W:
-      case GETSTATIC:
-      case GETSTATIC_QUICK:
-      case GETSTATIC2_QUICK:
-      case PUTSTATIC:
-      case PUTSTATIC_QUICK:
-      case PUTSTATIC2_QUICK:
+      case Const.GETFIELD:
+      case Const.PUTFIELD:
+      case Const.GETSTATIC:
+      case Const.PUTSTATIC:
         // Field usage
         checkField(getNameConstantOperand());
         break;
 
-      case LDC:
-      case LDC_W:
-      case LDC2_W:
+      case Const.LDC:
+      case Const.LDC_W:
+      case Const.LDC2_W:
         // Class usage
         if (getConstantRefOperand() instanceof ConstantClass) {
           // report bug in case it's google api @Beta class

--- a/google-http-client-findbugs/src/main/java/com/google/api/client/findbugs/package-info.java
+++ b/google-http-client-findbugs/src/main/java/com/google/api/client/findbugs/package-info.java
@@ -13,14 +13,17 @@
  */
 
 /**
- * Findbugs package which supports custom Google APIs Client library findbugs Plugins.
+ * SpotBugs package which supports the custom Google APIs Client Library SpotBugs plugin.
+ *
+ * <p>The artifact ID retains its historical {@code google-http-client-findbugs} name for
+ * compatibility.
  *
  * <p>Usage on pom.xml:
  *
  * <pre>
  * &lt;plugin&gt;
- * &lt;groupId>org.codehaus.mojo&lt;/groupId&gt;
- * &lt;artifactId>findbugs-maven-plugin&lt;/artifactId&gt;
+ * &lt;groupId&gt;com.github.spotbugs&lt;/groupId&gt;
+ * &lt;artifactId&gt;spotbugs-maven-plugin&lt;/artifactId&gt;
  * ...
  * &lt;configuration&gt;
  * &lt;plugins&gt;

--- a/google-http-client-findbugs/src/main/resources/messages.xml
+++ b/google-http-client-findbugs/src/main/resources/messages.xml
@@ -3,7 +3,7 @@
   xsi:noNamespaceSchemaLocation="messagecollection.xsd">
 
   <Plugin>
-    <ShortDescription>FindBugs Google API's Client library plugin</ShortDescription>
+    <ShortDescription>SpotBugs Google APIs Client Library plugin</ShortDescription>
     <Details>Provides detectors for Google APIs Client library.</Details>
   </Plugin>
 

--- a/google-http-client/src/main/java/com/google/api/client/util/Beta.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Beta.java
@@ -36,8 +36,9 @@ import java.lang.annotation.Target;
  * used in client applications, and if the wrong version of this library is used, it has the
  * potential to break client applications.
  *
- * <p>You may use the google-http-client-findbugs plugin to find usages of API bearing this
- * annotation.
+ * <p>You may use the SpotBugs plugin in the {@code google-http-client-findbugs} artifact to find
+ * usages of API bearing this annotation. The artifact ID retains its historical name for
+ * compatibility.
  *
  * @since 1.15
  * @author Eyal Peled

--- a/pom.xml
+++ b/pom.xml
@@ -366,9 +366,9 @@
           <version>3.6.0</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.5</version>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>4.8.6.8</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -503,10 +503,10 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
         <configuration>
-          <excludeFilterFile>${basedir}/../findbugs-exclude.xml</excludeFilterFile>
+          <excludeFilterFile>${basedir}/../spotbugs-exclude.xml</excludeFilterFile>
           <plugins>
             <plugin>
               <groupId>com.google.http-client</groupId>

--- a/samples/dailymotion-simple-cmdline-sample/pom.xml
+++ b/samples/dailymotion-simple-cmdline-sample/pom.xml
@@ -45,10 +45,10 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
         <configuration>
-          <excludeFilterFile>../../findbugs-exclude.xml</excludeFilterFile>
+          <excludeFilterFile>../../spotbugs-exclude.xml</excludeFilterFile>
           <failOnError>false</failOnError>
         </configuration>
         <executions>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <FindBugsFilter>
-  <!-- see http://findbugs.sourceforge.net/bugDescriptions.html -->
+  <!-- see https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html -->
   <LastVersion value="-1" relOp="NEQ"/>
   <!-- The following have not yet been investigated -->
   <!-- TODO(yanivi): investigate them -->


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-http-java-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2154 ☕️

This replaces the unsupported FindBugs engine and Maven plugin with SpotBugs while retaining the historical `google-http-client-findbugs` artifact ID for downstream compatibility.

The custom beta-API detector was updated for the current BCEL API while preserving its public API compatibility. Build configuration, exclusion filters, sample configuration, detector fixtures, and public Javadocs were updated accordingly.

Validation included:

- Full Java 8 reactor verification with tests skipped
- Clirr compatibility checks with no reported API changes
- Checkstyle validation
- Dependency verification confirming the obsolete FindBugs engine is no longer present
- Detector fixture verification for `BETA_CLASS_USAGE`, `BETA_FIELD_USAGE`, and `BETA_METHOD_USAGE`