### PR TITLE
fix: disconnect low-level response on construction failure to prevent connection leak

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -1022,10 +1022,17 @@ public final class HttpRequest {
           response = new HttpResponse(this, lowLevelHttpResponse);
           responseConstructed = true;
         } finally {
-          if (!responseConstructed) {
-            InputStream lowLevelContent = lowLevelHttpResponse.getContent();
-            if (lowLevelContent != null) {
-              lowLevelContent.close();
+          if (!responseConstructed && lowLevelHttpResponse != null) {
+            try {
+              InputStream lowLevelContent = lowLevelHttpResponse.getContent();
+              if (lowLevelContent != null) {
+                lowLevelContent.close();
+              }
+            } catch (IOException ignored) {
+            }
+            try {
+              lowLevelHttpResponse.disconnect();
+            } catch (IOException ignored) {
             }
           }
         }

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpRequestTest.java
@@ -1327,4 +1327,32 @@ public class HttpRequestTest {
         String.format("the loaded version '%s' did not match the acceptable pattern", version),
         version.matches(acceptableVersionPattern));
   }
+
+  @Test
+  public void testExecute_disconnectOnResponseConstructionFailure() throws Exception {
+    class FailingHttpResponse extends MockLowLevelHttpResponse {
+      @Override
+      public String getContentEncoding() {
+        throw new RuntimeException("Simulated response construction failure");
+      }
+    }
+
+    final FailingHttpResponse failingResponse = new FailingHttpResponse();
+    HttpTransport transport = new MockHttpTransport() {
+      @Override
+      public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+        return new MockLowLevelHttpRequest().setResponse(failingResponse);
+      }
+    };
+
+    HttpRequest req = transport.createRequestFactory().buildGetRequest(new GenericUrl("http://example.com"));
+    try {
+      req.execute();
+      fail("Expected RuntimeException");
+    } catch (RuntimeException e) {
+      assertEquals("Simulated response construction failure", e.getMessage());
+    }
+
+    assertTrue(failingResponse.isDisconnected());
+  }
 }


### PR DESCRIPTION
Summary
HttpResponse construction can throw a RuntimeException. The existing finally block in
HttpRequest.execute() closes the content stream in that case but never calls
LowLevelHttpResponse.disconnect(), leaving the socket open.

Changes
- HttpRequest.java: call disconnect() in the finally block when response construction
  fails; added null-guard and isolated getContent() failures so they don't suppress
  the disconnect() call.
- HttpRequestTest.java: added testExecute_disconnectOnResponseConstructionFailure.

Notes
Pre-existing bug, unrelated to the security hardening work (redirect credential stripping,
CRLF validation, XXE hardening) — those are separate PRs.

- [x] Opened an issue before writing code
- [x] Tests and linter pass
- [ ] Code coverage does not decrease
- [ ] Docs updated

Fixes #2177 ☕️