### PR TITLE
security: disable XML DTD processing in XmlPullParser to prevent XXE

### DIFF
--- a/google-http-client-xml/src/main/java/com/google/api/client/xml/Xml.java
+++ b/google-http-client-xml/src/main/java/com/google/api/client/xml/Xml.java
@@ -87,7 +87,13 @@ public class Xml {
 
   /** Returns a new XML pull parser. */
   public static XmlPullParser createParser() throws XmlPullParserException {
-    return getParserFactory().newPullParser();
+    XmlPullParser parser = getParserFactory().newPullParser();
+    try {
+      parser.setFeature(XmlPullParser.FEATURE_PROCESS_DOCDECL, false);
+    } catch (XmlPullParserException e) {
+      // Ignore if the feature is not supported
+    }
+    return parser;
   }
 
   /**

--- a/google-http-client-xml/src/test/java/com/google/api/client/xml/XmlTest.java
+++ b/google-http-client-xml/src/test/java/com/google/api/client/xml/XmlTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 import com.google.api.client.util.ArrayMap;
 import com.google.api.client.util.Key;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,6 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlSerializer;
 
 /**
@@ -620,5 +622,26 @@ public class XmlTest {
     @Key public XmlEnumTest.AnyEnum[] anyEnum;
     @Key public String[] stringArray;
     @Key public List<Integer> integerCollection;
+  }
+
+  @Test
+  public void testCreateParser_disablesDocDecl() throws Exception {
+    XmlPullParser parser = Xml.createParser();
+    String xmlWithDtd = "<?xml version=\"1.0\"?>\n"
+        + "<!DOCTYPE any [\n"
+        + "  <!ENTITY xxe \"injected\">\n"
+        + "]>\n"
+        + "<any>&xxe;</any>";
+    parser.setInput(new StringReader(xmlWithDtd));
+    try {
+      SimpleTypeString xml = new SimpleTypeString();
+      XmlNamespaceDictionary namespaceDictionary = new XmlNamespaceDictionary().set("", "");
+      Xml.parseElement(parser, xml, namespaceDictionary, null);
+      if (xml.value != null) {
+        assertTrue(xml.value.isEmpty() || xml.value.equals("&xxe;"));
+      }
+    } catch (XmlPullParserException | IOException e) {
+      // Expected exception if the parser fails on DOCDECL
+    }
   }
 }


### PR DESCRIPTION
Summary
Xml#createParser() did not disable FEATURE_PROCESS_DOCDECL, leaving the XmlPullParser
vulnerable to XML External Entity (XXE) injection when parsing attacker-influenced content.

Changes
- Xml.java: set FEATURE_PROCESS_DOCDECL=false immediately after parser creation, with a
  graceful try/catch fallback for parser implementations that don't support the feature.
- XmlTest.java: added testCreateParser_disablesDocDecl to verify DTD entity content is
  not resolved (or that the parser throws, both are safe outcomes).

- [x] Opened an issue before writing code
- [x] Tests and linter pass
- [ ] Code coverage does not decrease
- [ ] Docs updated

Fixes #2179 ☕️