### PR TITLE
security: validate header names and values to prevent CRLF injection

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpHeaders.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpHeaders.java
@@ -838,6 +838,9 @@ public class HttpHeaders extends GenericData {
     }
     // compute value
     String stringValue = toStringValue(value);
+    if (name.contains("\r") || name.contains("\n") || stringValue.contains("\r") || stringValue.contains("\n")) {
+      throw new IllegalArgumentException("Header name or value contains CRLF characters.");
+    }
     // log header
     String loggedStringValue = stringValue;
     if (("Authorization".equalsIgnoreCase(name) || "Cookie".equalsIgnoreCase(name))

--- a/google-http-client/src/test/java/com/google/api/client/http/HttpHeadersTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/HttpHeadersTest.java
@@ -17,6 +17,7 @@ package com.google.api.client.http;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.api.client.http.HttpRequestTest.E;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
@@ -322,4 +323,29 @@ public class HttpHeadersTest {
     assertNull(v.v);
     assertEquals("svalue", v.s);
   }
+
+  @Test
+  public void testSerializeHeaders_crlfInjectionInName() throws Exception {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("foo\r\nbar", "value");
+    try {
+      HttpHeaders.serializeHeaders(headers, null, null, null, new MockLowLevelHttpRequest(), null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testSerializeHeaders_crlfInjectionInValue() throws Exception {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("foo", "value\r\nbar");
+    try {
+      HttpHeaders.serializeHeaders(headers, null, null, null, new MockLowLevelHttpRequest(), null);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
 }
+


### PR DESCRIPTION
HttpHeaders#addHeader now rejects header names/values containing CR (\r) or LF (\n),
throwing IllegalArgumentException on CRLF injection attempts — prevents HTTP Header
Injection and Response Splitting.

Changes
- HttpHeaders.java: added CRLF validation in addHeader() after computing stringValue.
- HttpHeadersTest.java: added testSerializeHeaders_crlfInjectionInName and
  testSerializeHeaders_crlfInjectionInValue.

- [x] Opened an issue before writing code — #2180
- [x] Tests and linter pass
- [x] Code coverage does not decrease (2 new tests added)
- [ ] Docs updated

Fixes #2180 ☕️